### PR TITLE
Adapt project for Google Cloud Run deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copia o resto do código
 COPY . /app
 
-# Porta do Render
-ENV PORT=10000
+# Porta padrão para Cloud Run
+ENV PORT=8080
 
-# Comando de start (Uvicorn com a sua app)
-CMD ["uvicorn", "app_ui:app", "--host", "0.0.0.0", "--port", "10000"]
+# Comando de start (usa variável $PORT do Cloud Run)
+CMD ["sh", "-c", "uvicorn app_ui:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/README.md
+++ b/README.md
@@ -136,4 +136,28 @@ Edite `config/selectors.json` caso a sua UI seja diferente.
 - Instale fontes básicas no container (ex.: `fonts-liberation`, `fonts-noto`) ou aborte requisições de fonte.
 - Ajuste a frequência de health checks (30–60&nbsp;s) e, se possível, execute o espelho em processo separado do robô.
 
+## Deploy no Google Cloud Run (São Paulo)
+
+Exemplo usando `gcloud`:
+
+```bash
+# Console web
+gcloud builds submit --tag gcr.io/PROJECT-ID/duoke-console
+gcloud run deploy duoke-console \
+  --image gcr.io/PROJECT-ID/duoke-console \
+  --region southamerica-east1 \
+  --allow-unauthenticated
+
+# Worker (Cloud Run Job)
+gcloud builds submit --tag gcr.io/PROJECT-ID/duoke-bot
+gcloud run jobs create duoke-bot \
+  --image gcr.io/PROJECT-ID/duoke-bot \
+  --region southamerica-east1
+
+# Executar manualmente o job
+gcloud run jobs execute duoke-bot --region southamerica-east1
+```
+
+O arquivo `cloudrun.yaml` traz um modelo de configuração para esses recursos.
+
 Bom uso!

--- a/cloudrun.yaml
+++ b/cloudrun.yaml
@@ -1,0 +1,31 @@
+# Cloud Run service for the web console
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: duoke-console
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/PROJECT-ID/duoke-console
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          command: ["sh", "-c", "uvicorn app_ui:app --host 0.0.0.0 --port $PORT"]
+---
+# Cloud Run job for the background worker
+apiVersion: run.googleapis.com/v1
+kind: Job
+metadata:
+  name: duoke-bot
+spec:
+  template:
+    template:
+      spec:
+        containers:
+          - image: gcr.io/PROJECT-ID/duoke-bot
+            command: ["python", "-m", "src.run_loop"]
+            env:
+              - name: PYTHONUNBUFFERED
+                value: "1"
+        restartPolicy: Never


### PR DESCRIPTION
## Summary
- allow container to read Cloud Run's `$PORT` at startup
- add sample Cloud Run service and job definitions
- document deployment steps for region `southamerica-east1`

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v Dockerfile.py) && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0afe9d8832ab7027bb285a2ea4d