### PR TITLE
Handle conversations regardless of who sent last message

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -17,6 +17,7 @@
   "send_button": "button:has-text('Send'), button:has-text('Enviar')",
 
   "filter_needs_reply": "text=Precisa responder, text=Need Reply, text=Pending Reply",
+  "filter_all_conversations": "text=Todos, text=All, text=All messages, text=Todas",
 
   "tag_modal": ".el-dialog.select_label_dialog, .el-dialog:has(.select_label_content), .el-dialog__wrapper:has(.select_label_content)",
 

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -391,6 +391,20 @@ class DuokeBot:
         except Exception:
             pass
 
+    async def show_all_conversations(self, page):
+        """Garante que todas as conversas estejam visíveis, removendo filtros como 'Precisa responder'."""
+        try:
+            sel = SEL.get("filter_all_conversations", "")
+            if not sel:
+                return
+            locator = page.locator(sel)
+            if await locator.count() > 0:
+                await locator.first.click()
+                await page.wait_for_timeout(1000)
+        except Exception:
+            # Não deve interromper o fluxo se o seletor não existir ou falhar
+            pass
+
     # ---------- navegação entre conversas ----------
 
     def conversations(self, page):
@@ -720,7 +734,8 @@ class DuokeBot:
             await asyncio.sleep(1)
             return
 
-        await self.apply_needs_reply_filter(page)
+        # Garante que conversas cujo último envio foi do vendedor também apareçam
+        await self.show_all_conversations(page)
 
         conv_locator = self.conversations(page)
         await page.wait_for_timeout(300)


### PR DESCRIPTION
## Summary
- ensure chat list shows all conversations by adding a generic "all" filter selector
- add `show_all_conversations` helper and use it when cycling to include threads where last message is from seller

## Testing
- `python -m py_compile src/duoke.py`
- `python -m json.tool config/selectors.json >/tmp/selectors-formatted.json`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68a4bf231bd0832abe05e1028c7a586d