### PR TITLE
Prevent breakage false positives before delivery

### DIFF
--- a/app_ui.py
+++ b/app_ui.py
@@ -605,9 +605,9 @@ async def _run_cycle(run_once: bool):
     _bot = DuokeBot()
 
     # Hook para UI ver o que foi lido e a resposta sugerida
-    async def hook(messages: list[str]) -> tuple[bool, str]:
+    async def hook(messages: list[str], order_info=None) -> tuple[bool, str]:
         ws_broadcast({"snapshot": {"reading": [["buyer", m] for m in messages], "proposed": "", "running": True}})
-        should, reply = decide_reply(messages)
+        should, reply = decide_reply(messages, order_info)
         ws_broadcast({"snapshot": {"reading": [["buyer", m] for m in messages], "proposed": reply, "running": True}})
         return should, reply
 

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -777,8 +777,10 @@ class DuokeBot:
             reply = ""
             try:
                 params = inspect.signature(decide_reply_fn).parameters
-                if len(params) >= 2:
-                    result = decide_reply_fn(pairs, buyer_only)
+                if len(params) >= 3:
+                    result = decide_reply_fn(pairs, buyer_only, order_info)
+                elif len(params) >= 2:
+                    result = decide_reply_fn(buyer_only, order_info)
                 else:
                     result = decide_reply_fn(buyer_only)
                 if inspect.isawaitable(result):

--- a/templates/templates.json
+++ b/templates/templates.json
@@ -34,7 +34,9 @@
   "envio": "Seu pedido já foi enviado e está em trânsito pela Shopee Xpress. Você pode acompanhar o rastreio pelo app. Qualquer dúvida, estou à disposição!",
   
   "agradecimento_generico": "Agradecemos pela compra e confiança 😊 Conte conosco para qualquer dúvida ou necessidade.",
-  
+
+  "pre_envio_tranquilizacao": "Pode ficar tranquilo(a)! Embalamos tudo com bastante cuidado e deve chegar certinho. Qualquer coisa, estamos por aqui! 😊",
+
   "default": "Obrigado pela mensagem! Para agilizar o atendimento, envie por favor o número do pedido e, se possível, fotos ou detalhes do caso.",
   
   "nao_recebido_marcado_recebido": "Sinto muito pelo transtorno! 😔 Vi que o pedido consta como entregue/recebido, mas você não recebeu. Por favor:\n1️⃣ Confirme com vizinhos/porteiro se ficou com alguém por engano.\n2️⃣ Se não localizar, abra no app Shopee: *Ajuda > Não recebi meu pedido* e informe que o entregador marcou como recebido.\n\nMe envie o número do pedido e, se possível, um print da tela que mostra “recebido”. Vou priorizar seu caso.",


### PR DESCRIPTION
## Summary
- Pass order status info into classifier
- Add deterministic check to avoid breakage replies when buyer only expresses wish or order not delivered
- Provide reassurance template for pre-delivery expectations

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Dockerfile.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a4cab56f7c832a828ce59d57598639