### PR TITLE
Add regex intents and improve bot stability

### DIFF
--- a/config/catalog_rules.json
+++ b/config/catalog_rules.json
@@ -1,0 +1,10 @@
+[
+  {
+    "match": ["Painel Redondo", "Kit Festa Jogo de Cilindro", "Cilindros MDF"],
+    "pecas_padrao": 2,
+    "pecas_grandes": 3,
+    "limite_peca_unica_cm": 80,
+    "suporta_letras_douradas": true,
+    "producao_dias_uteis": 2
+  }
+]

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -60,3 +60,21 @@ def _fallback_classify(messages: list[str]) -> dict:
     if has("prazo","quando chega","não chegou","rastreamento","código"):
         return {"intent":"envio","reason":"dúvida logística","needs_reply":True}
     return {"intent":"envio","reason":"fallback neutro","needs_reply":True}
+
+def refine_reply(reply: str, buyer_text: str = "") -> str:
+    """Refine a reply using Gemini if API key is available."""
+    if not settings.gemini_api_key:
+        return reply
+    try:
+        model = get_gemini()
+        prompt = (
+            "Você é um assistente de atendimento ao cliente. "
+            "Melhore a resposta abaixo mantendo-a curta e educada.\n\n"
+            f"Pergunta do cliente: {buyer_text}\nResposta: {reply}"
+        )
+        resp = model.generate_content(prompt)
+        text = (resp.text or "").strip()
+        return text or reply
+    except Exception:
+        return reply
+

--- a/src/run_once.py
+++ b/src/run_once.py
@@ -13,11 +13,11 @@ async def main():
     bot = DuokeBot()
 
     # Função síncrona (NÃO async) para evitar "coroutine was never awaited"
-    def debug_reply(messages: list[str]) -> tuple[bool, str]:
+    def debug_reply(pairs, buyer_only, order_info=None) -> tuple[bool, str]:
         print("[DEBUG] Mensagens recebidas para classificação:")
-        for msg in messages:
-            print("-", msg)
-        should, reply = decide_reply(messages)
+        for role, msg in pairs:
+            print(f"- {role}: {msg}")
+        should, reply = decide_reply(pairs, buyer_only, order_info)
         print(f"[DEBUG] Deve responder? {should} | Resposta: {reply}")
         return should, reply
 


### PR DESCRIPTION
## Summary
- implement regex-based intent classifier with optional LLM refinement
- add catalog-based pre-sale rules and responses
- enhance Playwright handling and bot cycle resilience

## Testing
- `python -m py_compile app_ui.py src/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d00b45f0832aab0fbfc38c084ef2