### PR TITLE
Add selectors for Shopee order details

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -23,5 +23,23 @@
 
   "tag_item": ".label_container .label_item .label_item_name, .label_container .label_item, span.label_item_name",
 
-  "tag_confirm": ".el-dialog__footer .el-button--primary, .select_label_dialog .el-button--primary"
+  "tag_confirm": ".el-dialog__footer .el-button--primary, .select_label_dialog .el-button--primary",
+
+  "order_status_tag": "div.order_item_status .el-tag",
+  "order_code": "div.order_item_title span.mr_4",
+  "order_datetime": "div.order_item_time",
+  "product_title": ".order_item_products .product_url",
+  "product_variation": ".order_item_products_item_info_variation_name span",
+  "product_sku": ".order_item_products_item_info_sku span",
+  "product_price": ".order_item_products .product_other_info > div:nth-child(1)",
+  "product_qty": ".order_item_products .product_other_info > div:nth-child(2)",
+  "buyer_payment_amount": "div.order_item_buyer .flex:has(label[title='Buyer payment amount']) span.fw_700",
+  "payment_method": "div.order_item_buyer .flex:has(label[title='Payment Method']) span",
+  "payment_time": "div.order_item_buyer .flex:has(label[title='Payment Time']) span",
+  "shipping_provider": "div.order_item_logistics .flex:has(label[title='Shipping Provider']) span",
+  "tracking_number": "div.order_item_logistics .tracking_code",
+  "logistics_status": "div.order_item_logistics .flex:has(label[title='Logistics Status']) span[title]",
+  "latest_logistics_description": "div.order_item_logistics .flex:has(label[title='Latest Logistics Description']) .el-popover__reference",
+  "logistics_update_time": "div.order_item_logistics .flex:has(label[title='Logistics Update Time']) span.t_r",
+  "completed_time": "div.order_item_logistics .flex:has(label[title='Completed Time']) span"
 }


### PR DESCRIPTION
## Summary
- extend `selectors.json` with selectors for order status, codes, logistics, and payment details in right panel

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v Dockerfile.py)`

------
https://chatgpt.com/codex/tasks/task_e_68a507791af0832ab032b5814b5701ea