### PR TITLE
Ignore seller messages and handle 'not checked yet' replies

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -772,7 +772,8 @@ class DuokeBot:
             depth = int(getattr(settings, "history_depth", 8) or 8)
             pairs = await self.read_messages_with_roles(page, depth * 2)
             print(f"[DEBUG] conversa {i}: {len(pairs)} msgs (com role)")
-            if not pairs:
+            if not pairs or pairs[-1][0] != "buyer":
+                print("[DEBUG] Última mensagem não é do comprador; pulando conversa.")
                 continue
 
             buyer_only = [t for r, t in pairs if r == "buyer"][-depth:]


### PR DESCRIPTION
## Summary
- Skip conversations when the latest message is from the seller
- Classify and refine replies using only buyer text
- Reply politely when the customer says they haven't checked yet

## Testing
- `python -m py_compile src/classifier.py src/duoke.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5132ca7e4832a9ddfd2e9519fb4b4