### PR TITLE
Improve reply classification and refine prompts

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -121,33 +121,35 @@ def prod_defaults(prod: dict | None) -> dict:
 # -------------------- main --------------------
 
 def decide_reply(
-    pairs: List[Tuple[str, str]] | None,
+    _pairs: List[Tuple[str, str]] | None,
     buyer_only: List[str],
     order_info: dict | None = None,
 ) -> Tuple[bool, str]:
-    """Decide reply based on intent classification + rules with regex fallback.
+    """Decide reply based only on buyer messages.
 
-    1. Classifica o histórico para detectar intenção (ex.: "quebra").
-    2. Se houver regra específica para a intenção, usa o texto da regra.
-    3. Caso contrário, aplica as regras regex anteriores.
-    4. Sempre passa o resultado pelo ``refine_reply`` para polir o tom.
+    1. Classifica as últimas mensagens do comprador.
+    2. Se houver regra para a intenção detectada, usa ``rules.json``.
+    3. Caso contrário, aplica regex de fallback sobre ``buyer_only``.
+    4. O resultado passa por ``refine_reply`` para polir o tom.
     """
     order_info = order_info or {}
-    text = " | ".join(t for r, t in pairs[-3:] if r == "buyer") if pairs else " | ".join(buyer_only[-3:])
+    text = " | ".join(buyer_only[-3:])
     norm_text = _normalize(text)
     order_id = order_info.get("orderId", "")
-    messages = buyer_only
-    cls = classify(messages)
+    cls = classify(buyer_only)
     if cls.get("needs_reply") is False:
         return False, ""
 
-    if cls.get("intent") == "quebra":
-        signals = cls.get("signals") or {}
+    intent = cls.get("intent") or ""
+    signals = cls.get("signals") or {}
+    rule_id = intent
+    if intent == "quebra":
         rule_id = "quebra_com_foto" if signals.get("tem_foto") else "quebra_sem_foto"
-        base = get_reply_by_id(rule_id)
-        if base:
-            refined = refine_reply(base, norm_text)
-            return True, refined
+
+    base = get_reply_by_id(rule_id) if rule_id else None
+    if base:
+        refined = refine_reply(base, norm_text)
+        return True, refined
 
     reply = RESP_FALLBACK_CURTO
 

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -805,18 +805,8 @@ class DuokeBot:
             if not should:
                 continue
 
-            if order_info.get("status"):
-                if "status:" not in reply.lower():
-                    reply += f"\n\n_Status atual do pedido:_ **{order_info['status']}**"
             if order_info.get("orderId") and "{ORDER_ID}" in reply:
                 reply = reply.replace("{ORDER_ID}", order_info["orderId"])
-
-            tracking = await self.maybe_extract_tracking(page)
-            if tracking and "aplicativo da Shopee" in reply:
-                reply = reply.replace(
-                    "aplicativo da Shopee",
-                    f"aplicativo da Shopee (código {tracking})"
-                )
 
             await self.send_reply(page, reply)
             self.last_replied_at[conv_key] = now

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -157,7 +157,8 @@ REGRAS:
 - Não mencione/peça PIX/reembolso se o cliente falou disso.
 - Não altere políticas nem opções (apenas reescreva).
 - Mantenha 1–2 frases, claras e amistosas.
-- Se faltar informação essencial, peça **uma** coisa por vez.
+- Não use placeholders ou variáveis genéricas como "X", "Y" ou similares.
+- Se faltar informação essencial, peça **apenas um** esclarecimento específico e só se for necessário.
 
 ENTRADA:
 - Mensagem do cliente: {{BUYER}}
@@ -181,7 +182,8 @@ CHECKLIST:
 - Não prometa data de entrega.
 - Não fale de PIX/reembolso.
 - Não mude condições/opções originais.
-- Se o MANAGER pediu 1 esclarecimento, mantenha um pedido simples.
+- Sem placeholders genéricos (ex.: "X", "Y").
+- Só peça esclarecimento se indispensável e mantenha no máximo um pedido específico.
 
 ENTRADA:
 - Mensagem do cliente: {{BUYER}}


### PR DESCRIPTION
## Summary
- stop automatically appending order status/tracking info
- classify using only buyer messages and map intents to rules
- tighten manager/critic prompts to avoid placeholders and unnecessary questions

## Testing
- `python -m py_compile src/duoke.py src/classifier.py src/gemini_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a521c198c4832a94bc7639d5c2d46d