### PR TITLE
Pass order info dict to generate_reply

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -65,13 +65,10 @@ def decide_reply(
     if not history:
         history = "\n".join(msgs)
 
-    status = order_info.get("status_consolidado", "") if order_info else ""
-    logdesc = order_info.get("latest_desc", "") if order_info else ""
-
     # exemplo de uso do classificador regex (opcional)
     _ = intent_from_text(" ".join(msgs))
-    
-    reply = generate_reply(history, status=status, logdesc=logdesc)
+
+    reply = generate_reply(history, order_info=order_info)
     clean = _sanitize_reply(reply)
     if clean:
         return True, clean


### PR DESCRIPTION
## Summary
- Fix `generate_reply` call by passing `order_info` dict instead of individual kwargs

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ce2e674c832abd725b6075ac3554