### PR TITLE
feat: tag conversations for skips and missing parts

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -21,8 +21,9 @@
   "filter_needs_reply": "text=Precisa responder, text=Need Reply, text=Pending Reply",
   "filter_all_conversations": "text=Todos, text=All, text=All messages, text=Todas",
 
+  "tag_button": "i.icon_mark_1, .contact_action_icon i.icon_mark_1",
   "tag_modal": ".el-dialog.select_label_dialog, .el-dialog:has(.select_label_content), .el-dialog__wrapper:has(.select_label_content)",
-  "tag_item": ".label_container .label_item .label_item_name, .label_container .label_item, span.label_item_name",
+  "tag_item": ".label_item .label_item_name, .label_item, span.label_item_name",
   "tag_confirm": ".el-dialog__footer .el-button--primary, .select_label_dialog .el-button--primary",
 
   "order_status_tag": "div.order_item_status .order_item_status_tags .el-tag, div.order_item_status .el-tag",

--- a/src/config.py
+++ b/src/config.py
@@ -30,6 +30,9 @@ class Settings(BaseModel):
     delay_between_actions: float = Field(default_factory=lambda: float(os.getenv("DELAY_BETWEEN_ACTIONS", "0.1")))
     goto_timeout_ms: int = Field(default_factory=lambda: int(os.getenv("GOTO_TIMEOUT_MS", "60000")))
 
+    label_on_skip: str = Field(default_factory=lambda: os.getenv("LABEL_ON_SKIP", "gpt"))
+    label_on_missing_parts: str = Field(default_factory=lambda: os.getenv("LABEL_ON_MISSING_PARTS", "gpt"))
+
     # --- Cloud Run / Servidor ---
     port: int = Field(default_factory=lambda: int(os.getenv("PORT", "8080")))
     host: str = Field(default_factory=lambda: os.getenv("HOST", "0.0.0.0"))


### PR DESCRIPTION
## Summary
- add selectors and helpers to apply a label to conversations
- detect customer requests for missing parts and tag them
- support configurable label names for skip and missing parts cases

## Testing
- `python -m py_compile src/duoke.py src/config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5db0895e4832aa58467d2211d52b0