### PR TITLE
Add CSV logging and export endpoint

### DIFF
--- a/app_ui.py
+++ b/app_ui.py
@@ -23,7 +23,7 @@ from fastapi import (
     HTTPException,
     Response,
 )
-from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Template
 
@@ -127,6 +127,9 @@ HTML = Template(
           <div class="row" style="margin-top:8px;">
             <button id="sendBtn">Enviar</button>
             <button id="skipBtn" class="secondary">Pular</button>
+          </div>
+          <div class="row" style="margin-top:8px;">
+            <a class="secondary" href="/export-cases" style="text-decoration:none;padding:10px 14px;border:1px solid var(--br);">Exportar CSV</a>
           </div>
 
           <div class="row" style="margin-top:8px;">
@@ -388,6 +391,15 @@ async def root_head() -> Response:
 async def health_check() -> dict:
     """Health check endpoint used by deployment platforms."""
     return {"status": "ok"}
+
+
+@app.get("/export-cases")
+async def export_cases():
+    p = Path("data/atendimentos.csv")
+    if not p.exists():
+        return JSONResponse({"ok": False, "error": "Nenhum registro ainda."}, status_code=404)
+    # Faz download do CSV
+    return FileResponse(str(p), media_type="text/csv", filename="atendimentos.csv")
 
 
 # Monta /static somente se a pasta existir (evita erro em ambientes sem assets)

--- a/src/cases.py
+++ b/src/cases.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from pathlib import Path
+import csv
+from datetime import datetime, timezone
+from typing import List, Dict, Any
+
+DATA_DIR = Path("data")
+DATA_DIR.mkdir(exist_ok=True)
+CSV_PATH = DATA_DIR / "atendimentos.csv"
+
+HEADER = [
+    "timestamp_utc",
+    "order_id",
+    "status",
+    "produto",
+    "variacao",
+    "sku",
+    "problema",
+    "ultima_msg_comprador",
+]
+
+
+def _ensure_header():
+    if not CSV_PATH.exists():
+        with CSV_PATH.open("w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(HEADER)
+
+
+def infer_problema(buyer_msgs: List[str]) -> str:
+    """
+    Heurística simples: usa a última mensagem do cliente.
+    (Depois dá pra trocar por classificador, regras, etc.)
+    """
+    if not buyer_msgs:
+        return ""
+    return buyer_msgs[-1].strip().replace("\n", " ")
+
+
+def append_row(order_info: Dict[str, Any], buyer_only: List[str]):
+    _ensure_header()
+    row = [
+        datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        order_info.get("orderId", ""),
+        order_info.get("status", ""),
+        order_info.get("title", ""),
+        order_info.get("variation", ""),
+        order_info.get("sku", ""),
+        infer_problema(buyer_only),
+        buyer_only[-1].strip().replace("\n", " ") if buyer_only else "",
+    ]
+    with CSV_PATH.open("a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(row)

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -15,6 +15,7 @@ from playwright.async_api import (
 )
 from .config import settings
 from .classifier import RESP_FALLBACK_CURTO
+from .cases import append_row as log_case
 
 # Carrega seletores configuráveis
 SEL = json.loads(
@@ -1094,6 +1095,12 @@ class DuokeBot:
             await page.wait_for_timeout(
                 int(getattr(settings, "delay_between_actions", 1.0) * 1000)
             )
+
+            # registra o atendimento no CSV
+            try:
+                log_case(order_info, buyer_only)
+            except Exception as e:
+                print(f"[DEBUG] falha ao registrar atendimento: {e}")
 
     async def run_once(self, decide_reply_fn):
         """Modo pontual (mantido por compat)."""


### PR DESCRIPTION
## Summary
- log customer service cases to `data/atendimentos.csv`
- record each reply cycle and allow CSV download via `/export-cases`

## Testing
- `python -m py_compile src/cases.py src/duoke.py app_ui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a64d60aa60832a8eb99bbf0c8865fe