### PR TITLE
Refine message selectors and conversation handling

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -1,14 +1,18 @@
 {
   "chat_list_item": ".list_container_content .virtual_list .list > li, .contact_list .virtual_list .list > li",
 
-  "message_container": "ul.message_main.watermark_shopee, ul.message_main",
+  "messages_container": "ul.message_main.watermark_shopee, ul.message_main",
 
-  "buyer_message": "ul.message_main li.lt .msg_text .text_cont, ul.message_main li.lt .text_cont, ul.message_main li.lt .bubble .text, ul.message_main li.lt .record_item .content",
+  "buyer_bubbles": "ul.message_main li.lt .msg_cont .msg_text .text_cont",
+  "buyer_bubbles_fallback": "ul.message_main li.lt .text_cont",
+
+  "seller_bubbles": "ul.message_main li.rt .msg_cont .msg_text .text_cont",
+  "seller_bubbles_fallback": "ul.message_main li.rt .text_cont",
+
+  "buyer_badge_noise": "ul.message_main li.lt .send_account",
+  "quote_blocks": "ul.message_main li .quote_msg, ul.message_main li .quote_msg_cont",
+
   "buyer_name": ".cont_header .cont_info_name, .cont_header .contact_name, .chat_header .user_name",
-
-  "seller_message": "ul.message_main li.rt .msg_text .text_cont, ul.message_main li.rt .text_cont, ul.message_main li.rt .bubble .text, ul.message_main li.rt .record_item .content",
-
-  "message_text": "ul.message_main .msg_text .text_cont, ul.message_main .text_cont, ul.message_main .bubble .text, ul.message_main .record_item .content",
 
   "input_textarea": "textarea, [contenteditable='true']",
 
@@ -27,16 +31,16 @@
   "tag_item_active": ".label_item.active",
   "tag_confirm": ".el-dialog__footer .el-button--primary, .select_label_dialog .el-button--primary",
 
-  "order_status_tag": "div.order_item_status .order_item_status_tags .el-tag, div.order_item_status .el-tag",
+  "status_badge": "div.order_item_status .el-tag",
+  "order_status_tag": "div.order_item_status .el-tag",
 
-  "order_code": "div.order_item_title span.mr_4",
-  "order_datetime": "div.order_item_time",
-
-  "product_title": ".order_item_products .product_url",
-  "product_variation": ".order_item_products_item_info_variation_name span",
-  "product_sku": ".order_item_products_item_info_sku span",
-  "product_price": ".order_item_products .product_other_info > div:nth-child(1)",
-  "product_qty": ".order_item_products .product_other_info > div:nth-child(2)",
+  "order_items_root": "div.order_item_products",
+  "order_item": "div.order_item_products_item",
+  "item_title": ".order_item_products_item_info_title_name_url .product_url",
+  "item_variation": ".order_item_products_item_info_variation_name span[title]",
+  "item_sku": ".order_item_products_item_info_sku span[title]",
+  "item_price_block": ".product_other_info > div:nth-child(1)",
+  "item_qty_block": ".product_other_info > div:nth-child(3)",
 
   "buyer_payment_amount": "div.order_item_buyer .flex:has(label[title='Buyer payment amount']) span.fw_700",
   "payment_method": "div.order_item_buyer .flex:has(label[title='Payment Method']) span",

--- a/src/cases.py
+++ b/src/cases.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import csv
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
@@ -9,6 +10,8 @@ DATA_DIR = Path("data")
 DATA_DIR.mkdir(exist_ok=True)
 CSV_PATH = DATA_DIR / "atendimentos.csv"
 XLSX_PATH = DATA_DIR / "atendimentos.xlsx"
+SNAPSHOTS_PATH = DATA_DIR / "conversation_snapshots.jsonl"
+SKIPPED_PATH = DATA_DIR / "conversation_skips.jsonl"
 
 HEADER = [
     "timestamp_utc",
@@ -93,3 +96,20 @@ def export_to_excel() -> None:
         for r in csv.reader(f):
             ws.append(r)
     wb.save(XLSX_PATH)
+
+
+def save_conversation_snapshot(data: Dict[str, Any]) -> None:
+    SNAPSHOTS_PATH.parent.mkdir(exist_ok=True)
+    with SNAPSHOTS_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(data, ensure_ascii=False) + "\n")
+
+
+def mark_conversation_skipped(order_id: str, reason: str) -> None:
+    payload = {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "order_id": order_id,
+        "reason": reason,
+    }
+    SKIPPED_PATH.parent.mkdir(exist_ok=True)
+    with SKIPPED_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, ensure_ascii=False) + "\n")

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -15,7 +15,11 @@ from playwright.async_api import (
 )
 from .config import settings
 from .classifier import RESP_FALLBACK_CURTO
-from .cases import append_row as log_case
+from .cases import (
+    append_row as log_case,
+    save_conversation_snapshot,
+    mark_conversation_skipped,
+)
 
 # Carrega seletores configuráveis
 SEL = json.loads(
@@ -47,6 +51,203 @@ def buyer_wants_missing_parts(text: str) -> bool:
         "prefiro receber a peça",
     ]
     return any(s in t for s in simples)
+
+
+NOISE_SUBSTRINGS = (
+    "FAQ History",
+    "[The referenced message cannot be found]",
+)
+
+
+def _clean(t: str) -> str:
+    t = (t or "").replace("\u200b", "").strip()
+    return re.sub(r"\s+", " ", t)
+
+
+def _parse_money_br(txt: str) -> float:
+    txt = _clean(txt)
+    if not txt:
+        return 0.0
+    num = re.sub(r"[^0-9,]", "", txt)
+    num = num.replace(".", "").replace(",", ".")
+    try:
+        return float(num)
+    except ValueError:
+        return 0.0
+
+
+def _parse_qty(txt: str) -> int:
+    txt = _clean(txt)
+    m = re.search(r"(\d+)", txt)
+    return int(m.group(1)) if m else 0
+
+
+async def get_last_buyer_texts(page, limit=20) -> list[str]:
+    await page.wait_for_selector(SEL["messages_container"], timeout=15000)
+
+    try:
+        await page.eval_on_selector_all(
+            SEL["buyer_badge_noise"], "nodes => nodes.forEach(n => n.remove())"
+        )
+    except Exception:
+        pass
+    try:
+        await page.eval_on_selector_all(
+            SEL["quote_blocks"], "nodes => nodes.forEach(n => n.remove())"
+        )
+    except Exception:
+        pass
+
+    texts = await page.eval_on_selector_all(
+        SEL["buyer_bubbles"],
+        "nodes => nodes.map(n => n.textContent || '').filter(Boolean)",
+    )
+
+    if len(texts) < 5:
+        await page.mouse.wheel(0, -1500)
+        await page.wait_for_timeout(600)
+        texts = await page.eval_on_selector_all(
+            SEL["buyer_bubbles"],
+            "nodes => nodes.map(n => n.textContent || '').filter(Boolean)",
+        )
+
+    if not texts:
+        texts = await page.eval_on_selector_all(
+            SEL["buyer_bubbles_fallback"],
+            "nodes => nodes.map(n => n.textContent || '').filter(Boolean)",
+        )
+
+    cleaned = []
+    for raw in texts:
+        t = _clean(raw)
+        if not t:
+            continue
+        if any(x.lower() in t.lower() for x in NOISE_SUBSTRINGS):
+            continue
+        cleaned.append(t)
+
+    return cleaned[-limit:]
+
+
+async def get_last_seller_texts(page, limit=30) -> list[str]:
+    await page.wait_for_selector(SEL["messages_container"], timeout=15000)
+
+    try:
+        await page.eval_on_selector_all(
+            SEL["quote_blocks"], "nodes => nodes.forEach(n => n.remove())"
+        )
+    except Exception:
+        pass
+
+    texts = await page.eval_on_selector_all(
+        SEL["seller_bubbles"],
+        "nodes => nodes.map(n => n.textContent || '').filter(Boolean)",
+    )
+    if not texts:
+        texts = await page.eval_on_selector_all(
+            SEL["seller_bubbles_fallback"],
+            "nodes => nodes.map(n => n.textContent || '').filter(Boolean)",
+        )
+
+    cleaned = []
+    for raw in texts:
+        t = _clean(raw)
+        if not t:
+            continue
+        if any(x.lower() in t.lower() for x in NOISE_SUBSTRINGS):
+            continue
+        cleaned.append(t)
+
+    return cleaned[-limit:]
+
+
+OFFER_PATTERNS = [
+    r"\b(reembols\w+|reembolso|estorno)\b",
+    r"\b(troca(r|remos)?|efetuar\s+troca|fazer\s+a\s+troca)\b",
+    r"\b(enviar(\s+a)?\s*(peça|peca)\s*(faltante|que faltou)?)\b",
+    r"\b(reenviar|reenvio)\b",
+    r"\b(devolver|devolu(c|ç)ão)\b",
+]
+OFFER_RE = re.compile("|".join(OFFER_PATTERNS), re.I)
+
+
+def seller_offered_resolution(msgs: list[str]) -> bool:
+    if not msgs:
+        return False
+    joined = " \n ".join(msgs)
+    return bool(OFFER_RE.search(joined))
+
+
+STATUS_RANK = {
+    "cancelled": 100,
+    "completed": 90,
+    "ready to ship": 60,
+    "to ship": 50,
+    "to pack": 40,
+    "to pay": 10,
+}
+
+
+def _norm_status(s: str) -> str:
+    s = (s or "").lower()
+    if "cancel" in s:
+        return "cancelled"
+    if "complete" in s or "deliver" in s:
+        return "completed"
+    if "ready to ship" in s:
+        return "ready to ship"
+    if "to ship" in s:
+        return "to ship"
+    if "to pack" in s:
+        return "to pack"
+    if "to pay" in s:
+        return "to pay"
+    return "unknown"
+
+
+async def get_status_consolidated(page) -> str:
+    badges = await page.eval_on_selector_all(
+        SEL["status_badge"],
+        "nodes => nodes.map(n => (n.textContent || '').trim()).filter(Boolean)",
+    )
+    mapped = [_norm_status(x) for x in badges]
+    return max(mapped, key=lambda x: STATUS_RANK.get(x, 0)) if mapped else "unknown"
+
+
+async def get_order_items(page) -> list[dict]:
+    await page.wait_for_selector(SEL["order_items_root"], timeout=15000)
+    items = []
+    for h in await page.query_selector_all(SEL["order_item"]):
+        title = await h.eval_on_selector(
+            SEL["item_title"],
+            "el => el.textContent || ''",
+        )
+        variation = await h.eval_on_selector(
+            SEL["item_variation"],
+            "el => el.getAttribute('title') || el.textContent || ''",
+        )
+        sku = await h.eval_on_selector(
+            SEL["item_sku"],
+            "el => el.getAttribute('title') || el.textContent || ''",
+        )
+        price_txt = await h.eval_on_selector(
+            SEL["item_price_block"],
+            "el => el.textContent || ''",
+        )
+        qty_txt = await h.eval_on_selector(
+            SEL["item_qty_block"],
+            "el => el.textContent || ''",
+        )
+        items.append(
+            {
+                "title": _clean(title),
+                "variation": _clean(variation),
+                "sku": _clean(sku),
+                "price": _parse_money_br(price_txt),
+                "qty": _parse_qty(qty_txt),
+            }
+        )
+    return items
 
 
 # Botões de confirmação comuns em modais (várias línguas)
@@ -468,8 +669,8 @@ class DuokeBot:
 
         # Aguarda painel renderizar
         try:
-            if SEL.get("message_container"):
-                await page.wait_for_selector(SEL["message_container"], timeout=9000)
+            if SEL.get("messages_container"):
+                await page.wait_for_selector(SEL["messages_container"], timeout=9000)
             await page.wait_for_function(
                 """() => {
                     const ul = document.querySelector('ul.message_main');
@@ -502,7 +703,7 @@ class DuokeBot:
             # Força mais histórico: rola ao topo algumas vezes
             try:
                 container = page.locator(
-                    SEL.get("message_container", "ul.message_main")
+                    SEL.get("messages_container", "ul.message_main")
                 ).first
                 for _ in range(3):
                     await container.evaluate("(el) => { el.scrollTop = 0; }")
@@ -528,29 +729,12 @@ class DuokeBot:
 
     async def read_messages(self, page, depth: int = 8) -> list[str]:
         """Compat: apenas textos do comprador."""
-        msgs: list[str] = []
-        container = page.locator(SEL.get("message_container", "ul.message_main")).first
-        if not await container.count():
-            print("[DEBUG] Nenhum container de mensagens encontrado")
-            return msgs
-
-        for _ in range(3):
-            try:
-                await container.evaluate("(el) => { el.scrollTop = 0; }")
-                await page.wait_for_timeout(60)
-            except Exception:
-                break
-
-        buyer_sel = SEL.get("buyer_message", "ul.message_main li.lt .text_cont")
         try:
-            nodes = page.locator(buyer_sel)
-            msgs = await nodes.evaluate_all(
-                "(els) => els.map(el => (el.innerText || '').trim()).filter(Boolean)"
-            )
+            msgs = await get_last_buyer_texts(page, limit=depth)
             print(f"[DEBUG] Mensagens do cliente encontradas: {len(msgs)}")
-            return msgs[-depth:]
+            return msgs
         except Exception as e:
-            print(f"[DEBUG] erro ao extrair mensagens com evaluate_all: {e}")
+            print(f"[DEBUG] erro ao extrair mensagens: {e}")
             return []
 
     # ---------- painel lateral (pedido) ----------
@@ -1003,12 +1187,39 @@ class DuokeBot:
                 )
                 order_info["logistics_latest_desc"] = latest_desc
 
+                try:
+                    order_info["status_consolidado"] = await get_status_consolidated(page)
+                except Exception:
+                    pass
+                try:
+                    order_info["items"] = await get_order_items(page)
+                except Exception:
+                    pass
+
                 print("[DEBUG] Order info:", order_info)
             except Exception as e:
                 order_info = {}
                 print(f"[DEBUG] falha ao ler order_info: {e}")
 
             # ----- Mensagens + history -----
+            buyer_msgs = await get_last_buyer_texts(page, limit=20)
+            seller_msgs = await get_last_seller_texts(page, limit=30)
+            offered = seller_offered_resolution(seller_msgs)
+            save_conversation_snapshot(
+                {
+                    "order_id": order_info.get("orderId"),
+                    "buyer_last_20": buyer_msgs,
+                    "seller_last_30": seller_msgs,
+                    "offered_resolution": offered,
+                }
+            )
+            if offered:
+                mark_conversation_skipped(
+                    order_info.get("orderId"),
+                    reason="prior_offer_exchange_or_refund",
+                )
+                continue
+
             depth = int(getattr(settings, "history_depth", 8) or 8)
             pairs = await self.read_messages_with_roles(page, depth * 2)
             print(f"[DEBUG] conversa {i}: {len(pairs)} msgs (com role)")


### PR DESCRIPTION
## Summary
- update message and order item selectors to match current UI
- add helpers to clean and collect buyer/seller messages and detect prior offers
- log conversation snapshots and skip when seller already offered resolution

## Testing
- `python -m py_compile src/duoke.py src/cases.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a65c321cd8832a892db03ce94844c0