### PR TITLE
Log messages and replies during cycles

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -819,6 +819,7 @@ class DuokeBot:
     # ---------- envio de resposta ----------
 
     async def send_reply(self, page, text: str):
+        print(f"[DEBUG] Enviando resposta: {text}")
         candidates = [
             s.strip() for s in SEL.get("input_textarea", "").split(",") if s.strip()
         ]
@@ -1225,6 +1226,10 @@ class DuokeBot:
             print(f"[DEBUG] conversa {i}: {len(pairs)} msgs (com role)")
             if not pairs:
                 continue
+
+            print("[DEBUG] Mensagens lidas:")
+            for role, msg in pairs:
+                print(f"- {role}: {msg}")
 
             buyer_only = [t for r, t in pairs if r == "buyer"][-depth:]
 


### PR DESCRIPTION
## Summary
- Print every message pair read in a conversation cycle for easier debugging
- Log reply text before sending to ensure responses are visible

## Testing
- `python -m py_compile src/duoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6608988a4832a9d23f1bb8cb1e8a7