### PR TITLE
Refine chat iteration and response logic

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -1,4 +1,5 @@
 {
+  "chat_list_root": ".list_container_content .virtual_list, .contact_list .virtual_list",
   "chat_list_item": ".list_container_content .virtual_list .list > li, .contact_list .virtual_list .list > li",
 
   "messages_container": "ul.message_main.watermark_shopee, ul.message_main",


### PR DESCRIPTION
## Summary
- iterate through full conversation list with scroll to avoid skipped chats
- improve timeline parsing and message extraction for buyer and seller
- skip conversations only after unanswered resolution offer

## Testing
- `python -m pytest`
- `python -m py_compile src/duoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68a66831f854832ab8fdaf25ab7fc4f7