### PR TITLE
Add worker heartbeat and fix rules.json parsing

### DIFF
--- a/app_ui.py
+++ b/app_ui.py
@@ -666,6 +666,13 @@ async def _run_cycle(run_once: bool):
     LAST_ERR = None
     _bot = DuokeBot()
 
+    log("[READY] Worker iniciado")
+
+    async def _heartbeat():
+        while RUNNING:
+            log("[READY] heartbeat")
+            await asyncio.sleep(30)
+
     # Hook para UI ver o que foi lido e a resposta sugerida
     async def hook(pairs, buyer_only, order_info=None) -> tuple[bool, str]:
         ws_broadcast(
@@ -690,6 +697,7 @@ async def _run_cycle(run_once: bool):
         return should, reply
 
     mirror_task = asyncio.create_task(_mirror_loop())
+    hb_task = asyncio.create_task(_heartbeat())
     try:
         if run_once:
             await _bot.run_once(hook)  # uma passada
@@ -699,10 +707,11 @@ async def _run_cycle(run_once: bool):
         LAST_ERR = f"{type(e).__name__}: {e}"
         log(f"[ERROR] {type(e).__name__}: {e}")
     finally:
-        try:
-            mirror_task.cancel()
-        except Exception:
-            pass
+        for t in (mirror_task, hb_task):
+            try:
+                t.cancel()
+            except Exception:
+                pass
         RUNNING = False
         ws_broadcast({"snapshot": {"running": False}})
         _bot = None
@@ -713,6 +722,7 @@ async def start():
     global _task, RUNNING
     if RUNNING:
         return RedirectResponse("/", status_code=303)
+    log("[READY] start recebido, worker disparado")
     if not duoke_is_connected():
         log("[UI] Duoke não conectado. Faça login na aba Configurações.")
     ws_broadcast({"snapshot": {"running": True}})

--- a/rules.json
+++ b/rules.json
@@ -57,7 +57,7 @@
     "id": "cilindro_pequeno",
     "active": true,
     "match": {
-      "any_contains": ["cilindro pequeno", "cilindro não é grande", "cilindro errado", "cilindros compactos", "trio compacto"]
+      "any_contains": ["cilindro pequeno", "cilindro não é grande", "cilindro errado", "cilindros compactos", "trio compacto"],
       "none_contains": ["arco", "arcos", "painel", "painel pequeno", "painel grande", "arco de balão", "arco menor", "diâmetro do arco"]
     },
     "reply": "Boa tarde! Tudo bem? Poxa, sinto muito pela confusão. Esse anúncio é referente ao trio compacto (3 peças menores), como mostramos na descrição e nas imagens com as medidas. Para alcançar o tamanho padrão, muitos clientes usam 2 trios compactos. Se quiser completar, posso te oferecer 25% de desconto no segundo trio!"

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -1255,8 +1255,12 @@ class DuokeBot:
             await asyncio.sleep(1)
             return
 
-        # Garante que conversas cujo último envio foi do vendedor também apareçam
-        await self.show_all_conversations(page)
+        # Garante que o filtro "precisa responder" seja removido quando queremos
+        # responder mesmo que a última mensagem seja do vendedor
+        if RESPONDER_MESMO_SE_ULTIMA_FOR_SELLER:
+            await self.show_all_conversations(page)
+        else:
+            await self.apply_needs_reply_filter(page)
 
         max_convs = int(getattr(settings, "max_conversations", 0) or 0)
         i = -1


### PR DESCRIPTION
## Summary
- log start and heartbeat messages when worker launches
- handle seller-last conversations explicitly
- fix `rules.json` syntax to load properly

## Testing
- `python -m py_compile app_ui.py src/duoke.py`
- `python -m json.tool rules.json`


------
https://chatgpt.com/codex/tasks/task_e_68a6706cfc4c832a9e8270d718041da4