### PR TITLE
Stop applying labels; log order details

### DIFF
--- a/config/selectors.json
+++ b/config/selectors.json
@@ -27,10 +27,6 @@
   "filter_needs_reply": "text=Precisa responder, text=Need Reply, text=Pending Reply",
   "filter_all_conversations": "text=Todos, text=All, text=All messages, text=Todas",
 
-  "tag_button": ".cont_header .contact_action_icon:has(i.icon_mark_1), .contact_action .contact_action_icon:has(i.icon_mark_1)",
-  "tag_item": "span.label_item_name",
-  "tag_item_active": ".label_item.active",
-  "tag_confirm": ".el-dialog__footer .el-button--primary, .select_label_dialog .el-button--primary",
 
   "status_badge": "div.order_item_status .el-tag",
   "order_status_tag": "div.order_item_status .el-tag",

--- a/src/cases.py
+++ b/src/cases.py
@@ -9,6 +9,7 @@ DATA_DIR = Path("data")
 DATA_DIR.mkdir(exist_ok=True)
 CSV_PATH = DATA_DIR / "atendimentos.csv"
 XLSX_PATH = DATA_DIR / "atendimentos.xlsx"
+LABEL_CSV_PATH = DATA_DIR / "etiquetas.csv"
 
 HEADER = [
     "timestamp_utc",
@@ -22,12 +23,26 @@ HEADER = [
     "ultima_msg_comprador",
 ]
 
+LABEL_HEADER = [
+    "order_id",
+    "buyer_name",
+    "produto",
+    "sku",
+    "mensagem_comprador",
+]
+
 
 def _ensure_header():
     if not CSV_PATH.exists():
         with CSV_PATH.open("w", newline="", encoding="utf-8") as f:
             w = csv.writer(f)
             w.writerow(HEADER)
+
+
+def _ensure_label_header():
+    if not LABEL_CSV_PATH.exists():
+        with LABEL_CSV_PATH.open("w", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(LABEL_HEADER)
 
 
 TRIGGERS = {
@@ -83,6 +98,21 @@ def append_row(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
         csv.writer(f).writerow(row)
 
     export_to_excel()
+
+
+def append_label(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
+    """Salva informações básicas de pedidos que receberiam etiqueta."""
+    _ensure_label_header()
+    ultima_msg = buyer_only[-1].strip().replace("\n", " ") if buyer_only else ""
+    row = [
+        order_info.get("orderId", ""),
+        order_info.get("buyer_name", ""),
+        order_info.get("title", ""),
+        order_info.get("sku", ""),
+        ultima_msg,
+    ]
+    with LABEL_CSV_PATH.open("a", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerow(row)
 
 
 def export_to_excel() -> None:

--- a/src/config.py
+++ b/src/config.py
@@ -58,12 +58,6 @@ class Settings(BaseModel):
         default_factory=lambda: int(os.getenv("GOTO_TIMEOUT_MS", "60000"))
     )
 
-    label_on_skip: str = Field(
-        default_factory=lambda: os.getenv("LABEL_ON_SKIP", "gpt")
-    )
-    label_on_missing_parts: str = Field(
-        default_factory=lambda: os.getenv("LABEL_ON_MISSING_PARTS", "gpt")
-    )
 
     # --- Cloud Run / Servidor ---
     port: int = Field(default_factory=lambda: int(os.getenv("PORT", "8080")))


### PR DESCRIPTION
## Summary
- drop config and selectors for order tagging
- record order info (id, buyer, product, sku, last message) when tags would be applied
- remove unused label application routine

## Testing
- `python -m pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6fa76b404832ab03b5a15377d8cc7