### PR TITLE
Save skipped conversations and export at shutdown

### DIFF
--- a/src/cases.py
+++ b/src/cases.py
@@ -75,12 +75,23 @@ def infer_problema(buyer_msgs: List[str]) -> str:
 
 
 def append_row(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
+    """Registra informações básicas de atendimentos.
+
+    Conversas que são apenas "puladas" também devem ser salvas. Para isso, o
+    `Duoke` marca `order_info['skip']=True` antes de chamar esta função. Nesse
+    caso, gravamos a linha mesmo que `infer_problema` não retorne nada e
+    registramos "skip" na coluna `problema`.
+    """
+    skip = bool(order_info.get("skip"))
     problema = infer_problema(buyer_only)
-    if not problema:
+    if not problema and not skip:
         return
 
     _ensure_header()
     ultima_msg = buyer_only[-1].strip().replace("\n", " ") if buyer_only else ""
+
+    if skip and not problema:
+        problema = "skip"
 
     row = [
         datetime.now(timezone.utc).isoformat(timespec="seconds"),
@@ -96,8 +107,6 @@ def append_row(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
 
     with CSV_PATH.open("a", newline="", encoding="utf-8") as f:
         csv.writer(f).writerow(row)
-
-    export_to_excel()
 
 
 def append_label(order_info: Dict[str, Any], buyer_only: List[str]) -> None:

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -15,7 +15,7 @@ from playwright.async_api import (
 )
 from .config import settings
 from .classifier import RESP_FALLBACK_CURTO
-from .cases import append_row as log_case, append_label as log_label
+from .cases import append_row as log_case, append_label as log_label, export_to_excel
 
 # Carrega seletores configuráveis
 SEL = json.loads(
@@ -1011,6 +1011,7 @@ class DuokeBot:
             print(f"[DEBUG] decide: should={should} | Resposta: {reply}")
             decision_txt = (reply or "").strip().lower()
             if (not should) or decision_txt == "ação: skip (pular)".lower():
+                order_info["skip"] = True
                 try:
                     log_case(order_info, buyer_only)
                 except Exception as e:
@@ -1061,6 +1062,7 @@ class DuokeBot:
                 await ctx.close()
             finally:
                 self.current_page = None
+    export_to_excel()
 
     async def run_forever(self, decide_reply_fn, idle_seconds: float = 3.0):
         """
@@ -1101,3 +1103,4 @@ class DuokeBot:
                     except Exception:
                         pass
                     self.current_page = None
+    export_to_excel()


### PR DESCRIPTION
## Summary
- log skipped conversations by marking them and saving a CSV entry even when no problem is inferred
- export accumulated conversation data to Excel when the process stops in `run_once` or `run_forever`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a706821438832a981f6835302dd163