### PR TITLE
Salva conversas puladas e exporta planilha ao encerrar

### DIFF
--- a/src/cases.py
+++ b/src/cases.py
@@ -76,8 +76,6 @@ def infer_problema(buyer_msgs: List[str]) -> str:
 
 def append_row(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
     problema = infer_problema(buyer_only)
-    if not problema:
-        return
 
     _ensure_header()
     ultima_msg = buyer_only[-1].strip().replace("\n", " ") if buyer_only else ""
@@ -97,8 +95,6 @@ def append_row(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
     with CSV_PATH.open("a", newline="", encoding="utf-8") as f:
         csv.writer(f).writerow(row)
 
-    export_to_excel()
-
 
 def append_label(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
     """Salva informações básicas de pedidos que receberiam etiqueta."""
@@ -117,6 +113,8 @@ def append_label(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
 
 def export_to_excel() -> None:
     """Converte o CSV de atendimentos para um arquivo Excel."""
+    if not CSV_PATH.exists():
+        return
     wb = Workbook()
     ws = wb.active
     with CSV_PATH.open("r", newline="", encoding="utf-8") as f:

--- a/src/run_once.py
+++ b/src/run_once.py
@@ -3,6 +3,7 @@ import asyncio
 from pathlib import Path
 from .duoke import DuokeBot
 from .classifier import decide_reply
+from .cases import export_to_excel
 
 STATE_FILE = Path(__file__).resolve().parents[1] / "storage_state.json"
 
@@ -25,6 +26,10 @@ async def main():
         return should, reply
 
     await bot.run_once(debug_reply)
+    try:
+        export_to_excel()
+    except Exception as e:
+        print(f"[RUN_ONCE] falha ao exportar planilha: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Resumo
- Registra sempre os dados das conversas puladas, mesmo sem problema identificado
- Exporta a planilha de atendimentos ao finalizar os processos de execução

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a706821438832a981f6835302dd163