### PR TITLE
Add product management tab and Firebase lookup

### DIFF
--- a/app_ui.py
+++ b/app_ui.py
@@ -100,6 +100,7 @@ HTML = Template(
     <a href="#ativo" class="active" id="tab-ativo">Ativo</a>
     <a href="#config" id="tab-config">Configurações</a>
     <a href="#regras" id="tab-regras">Regras</a>
+    <a href="#produtos" id="tab-produtos">Produtos</a>
   </nav>
 
   <main class="wrap">
@@ -208,9 +209,37 @@ HTML = Template(
       </div>
     </section>
 
+    <!-- ABA PRODUTOS -->
+    <section id="pane-produtos" style="display:none;">
+      <div class="card" style="max-width:420px;">
+        <h3>Cadastro de Produtos</h3>
+        <form id="product-form" style="display:flex; flex-direction:column; gap:8px;">
+          <input name="nome" type="text" placeholder="Nome" required />
+          <input name="sku" type="text" placeholder="SKU" required />
+          <textarea name="descricao" rows="4" placeholder="Descrição"></textarea>
+          <input name="medidas" type="text" placeholder="Medidas" />
+          <button>Salvar</button>
+        </form>
+      </div>
+    </section>
+
   </main>
 
-<script>
+  <script type="module">
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js";
+import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyCFQGW574J5Y2N8xq1y-pLzNlLIptEn8_8",
+  authDomain: "chatshopee-5e5a8.firebaseapp.com",
+  projectId: "chatshopee-5e5a8",
+  storageBucket: "chatshopee-5e5a8.firebasestorage.app",
+  messagingSenderId: "196443025078",
+  appId: "1:196443025078:web:60af3b12e1af740f448017"
+};
+
+const fbApp = initializeApp(firebaseConfig);
+const db = getFirestore(fbApp);
 const screen = document.getElementById('screen');
 const reading = document.getElementById('reading');
 const proposed = document.getElementById('proposed');
@@ -278,10 +307,25 @@ async function loadRules() {
 }
 loadRules();
 
-document.getElementById('newRuleBtn').addEventListener('click', () => {
-  const form = document.querySelector('#pane-regras form');
-  form.reset();
-});
+  document.getElementById('newRuleBtn').addEventListener('click', () => {
+    const form = document.querySelector('#pane-regras form');
+    form.reset();
+  });
+
+  const productForm = document.getElementById('product-form');
+  if (productForm) {
+    productForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const data = Object.fromEntries(new FormData(productForm).entries());
+      try {
+        await setDoc(doc(db, 'products', data.sku), data);
+        alert('Produto salvo!');
+        productForm.reset();
+      } catch (err) {
+        alert('Erro ao salvar: ' + err);
+      }
+    });
+  }
 
 let ws;
 function connectWS(){

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -6,6 +6,7 @@ import re
 
 from .gemini_client import generate_reply
 from .config import settings
+from .firebase_client import get_product_by_sku
 
 RESP_FALLBACK_CURTO = "Desculpe, não entendi muito bem sua mensagem. Você poderia explicar um pouco melhor para que eu consiga te ajudar?"
 
@@ -69,6 +70,14 @@ def decide_reply(
     history = order_info.get("history_block") if order_info else None
     if not history:
         history = "\n".join(msgs)
+
+    # Busca dados do produto pelo SKU e injeta em order_info
+    sku = order_info.get("sku") if order_info else None
+    if sku:
+        prod = get_product_by_sku(sku)
+        if prod:
+            order_info = dict(order_info or {})
+            order_info["product_info"] = prod
 
     # exemplo de uso do classificador regex (opcional)
     _ = intent_from_text(" ".join(msgs))

--- a/src/firebase_client.py
+++ b/src/firebase_client.py
@@ -1,0 +1,31 @@
+import json
+from typing import Dict
+from urllib.request import urlopen
+
+FIREBASE_CONFIG = {
+    "apiKey": "AIzaSyCFQGW574J5Y2N8xq1y-pLzNlLIptEn8_8",
+    "projectId": "chatshopee-5e5a8",
+}
+
+
+def get_product_by_sku(sku: str) -> Dict[str, str]:
+    """Fetch product information from Firestore by SKU."""
+    if not sku:
+        return {}
+    base = "https://firestore.googleapis.com/v1"
+    url = (
+        f"{base}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
+        f"products/{sku}?key={FIREBASE_CONFIG['apiKey']}"
+    )
+    try:
+        with urlopen(url) as resp:
+            data = json.load(resp)
+        fields = data.get("fields", {})
+        return {
+            "nome": fields.get("nome", {}).get("stringValue", ""),
+            "sku": fields.get("sku", {}).get("stringValue", sku),
+            "descricao": fields.get("descricao", {}).get("stringValue", ""),
+            "medidas": fields.get("medidas", {}).get("stringValue", ""),
+        }
+    except Exception:
+        return {}

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -94,6 +94,16 @@ def generate_reply(history: str, order_info: dict | None = None) -> str:
     try:
         model = get_gemini()
         contexto = _order_stage_context(order_info)
+        prod = order_info.get("product_info") if order_info else None
+        prod_context = ""
+        if prod:
+            prod_context = (
+                "[Dados do Produto]\n"
+                f"nome: {prod.get('nome','')}\n"
+                f"sku: {prod.get('sku','')}\n"
+                f"descricao: {prod.get('descricao','')}\n"
+                f"medidas: {prod.get('medidas','')}\n\n"
+            )
 
         prompt = f"""{settings.base_prompt}
 
@@ -103,7 +113,7 @@ INSTRUÇÕES ADICIONAIS (NÃO MOSTRAR AO CLIENTE):
 - Se a política for "pular" (ex.: pix/comprovante), devolva APENAS: "Ação: skip (pular)".
 - Caso contrário, devolva APENAS a mensagem final em 1–2 frases (sem "ID:", sem "Resposta:", sem análises).
 
-[Contexto do Pedido]
+{prod_context}[Contexto do Pedido]
 {contexto}
 
 [Conversa]


### PR DESCRIPTION
## Summary
- add Produtos tab with form to save product info to Firebase
- fetch product details by SKU for bot replies
- include product context when generating replies

## Testing
- `python -m py_compile src/firebase_client.py src/classifier.py src/gemini_client.py app_ui.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72462f4a4832a857f7fc57244520b