### PR TITLE
Persist buyer conversation history

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -20,6 +20,7 @@ from .cases import (
     append_label as log_label,
     infer_problema,
 )
+from .history import get_history, append_history
 
 # Carrega seletores configuráveis
 SEL = json.loads(
@@ -1045,6 +1046,15 @@ class DuokeBot:
             if not pairs:
                 continue
 
+            buyer_name = (order_info.get("buyer_name") or "").strip()
+            if buyer_name:
+                stored = get_history(buyer_name)
+                if stored:
+                    for p in pairs:
+                        if p not in stored:
+                            stored.append(p)
+                    pairs = stored
+
             buyer_only = [t for r, t in pairs if r == "buyer"][-depth:]
             problema = infer_problema(buyer_only)
             wants_parts = bool(buyer_only) and buyer_wants_missing_parts(buyer_only[-1])
@@ -1143,6 +1153,9 @@ class DuokeBot:
             await self.send_reply(page, reply)
             conv_sent.add(norm_reply)
             self.last_replied_at[conv_key] = now
+            if buyer_name:
+                append_history(buyer_name, pairs + [("seller", reply)], max_depth=depth * 2)
+
             await page.wait_for_timeout(
                 int(getattr(settings, "delay_between_actions", 1.0) * 1000)
             )

--- a/src/history.py
+++ b/src/history.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+DATA_DIR = Path("data")
+DATA_DIR.mkdir(exist_ok=True)
+HISTORY_PATH = DATA_DIR / "history.json"
+
+
+def _load_all() -> Dict[str, List[Dict[str, str]]]:
+    if not HISTORY_PATH.exists():
+        return {}
+    try:
+        with HISTORY_PATH.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _save_all(data: Dict[str, List[Dict[str, str]]]) -> None:
+    with HISTORY_PATH.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def get_history(buyer_name: str) -> List[Tuple[str, str]]:
+    data = _load_all()
+    raw = data.get(buyer_name, [])
+    return [(d.get("role", ""), d.get("text", "")) for d in raw]
+
+
+def append_history(buyer_name: str, pairs: List[Tuple[str, str]], max_depth: int = 20) -> None:
+    data = _load_all()
+    items = data.get(buyer_name, [])
+    for role, text in pairs:
+        entry = {"role": role, "text": text}
+        if entry not in items:
+            items.append(entry)
+    data[buyer_name] = items[-max_depth:]
+    _save_all(data)


### PR DESCRIPTION
## Summary
- store per-buyer conversation history in `data/history.json`
- resume chats using saved history and append new replies automatically

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile succeeded'`


------
https://chatgpt.com/codex/tasks/task_e_68af38415288832ab488510be36bcf98