### PR TITLE
Add chat history export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Por padrão, roda uma varredura a cada 120 segundos (config em `.env`).
 - Dúvidas comuns (envio/rastreio) → templates FAQ.
 - Permite **inserir código de rastreio** caso esteja visível (depende dos seletores e do layout atual).
 
+## Exportar histórico de conversas
+
+A interface web possui um botão **Exportar histórico** na aba *Atendimentos* que permite
+baixar o arquivo `history.json` com todas as mensagens salvas pelo bot.
+
 ## Estrutura
 
 ```

--- a/app_ui.py
+++ b/app_ui.py
@@ -217,6 +217,7 @@ HTML = Template(
         <h3>Atendimentos Salvos</h3>
         <div class="row" style="margin-bottom:8px;">
           <a class="secondary" href="/export-cases-xlsx" style="text-decoration:none;padding:10px 14px;border:1px solid var(--br);">Exportar Excel</a>
+          <a class="secondary" href="/export-history" style="text-decoration:none;padding:10px 14px;border:1px solid var(--br);">Exportar histórico</a>
         </div>
         <table>
           <thead>
@@ -540,6 +541,14 @@ async def export_cases_xlsx():
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         filename="atendimentos.xlsx",
     )
+
+
+@app.get("/export-history")
+async def export_history():
+    p = Path("data/history.json")
+    if not p.exists():
+        return JSONResponse({"ok": False, "error": "Nenhum histórico ainda."}, status_code=404)
+    return FileResponse(str(p), media_type="application/json", filename="history.json")
 
 
 # Monta /static somente se a pasta existir (evita erro em ambientes sem assets)


### PR DESCRIPTION
## Summary
- add link to download chat history from web UI
- expose `/export-history` endpoint to return `history.json`
- document chat history export in README

## Testing
- `python -m py_compile app_ui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af3b769f9c832a92b5a1bc4419a239