### PR TITLE
Persist buyer conversation history

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -20,6 +20,7 @@ from .cases import (
     append_label as log_label,
     infer_problema,
 )
+from .history import get_history, append_history
 
 # Carrega seletores configuráveis
 SEL = json.loads(
@@ -1045,6 +1046,15 @@ class DuokeBot:
             if not pairs:
                 continue
 
+            buyer_name = (order_info.get("buyer_name") or "").strip()
+            if buyer_name:
+                stored = get_history(buyer_name)
+                if stored:
+                    for p in pairs:
+                        if p not in stored:
+                            stored.append(p)
+                    pairs = stored
+
             buyer_only = [t for r, t in pairs if r == "buyer"][-depth:]
             problema = infer_problema(buyer_only)
             wants_parts = bool(buyer_only) and buyer_wants_missing_parts(buyer_only[-1])
@@ -1143,6 +1153,9 @@ class DuokeBot:
             await self.send_reply(page, reply)
             conv_sent.add(norm_reply)
             self.last_replied_at[conv_key] = now
+            if buyer_name:
+                append_history(buyer_name, pairs + [("seller", reply)], max_depth=depth * 2)
+
             await page.wait_for_timeout(
                 int(getattr(settings, "delay_between_actions", 1.0) * 1000)
             )

--- a/src/history.py
+++ b/src/history.py
@@ -1,0 +1,91 @@
+import json
+from typing import List, Tuple
+from urllib.request import Request, urlopen
+
+from .firebase_client import FIREBASE_CONFIG
+
+BASE_URL = "https://firestore.googleapis.com/v1"
+COLLECTION = "history"
+
+
+def _doc_id(buyer_name: str) -> str:
+    """Sanitize buyer name to be used as Firestore document id."""
+    return buyer_name.replace("/", "_")
+
+
+def get_history(buyer_name: str) -> List[Tuple[str, str]]:
+    """Retrieve conversation history for a buyer from Firestore."""
+    if not buyer_name:
+        return []
+    url = (
+        f"{BASE_URL}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
+        f"{COLLECTION}/{_doc_id(buyer_name)}?key={FIREBASE_CONFIG['apiKey']}"
+    )
+    try:
+        with urlopen(url) as resp:
+            data = json.load(resp)
+        raw = (
+            data.get("fields", {})
+            .get("conversation", {})
+            .get("stringValue", "")
+        )
+        if raw:
+            items = json.loads(raw)
+            return [(d.get("role", ""), d.get("text", "")) for d in items]
+    except Exception:
+        pass
+    return []
+
+
+def append_history(
+    buyer_name: str, pairs: List[Tuple[str, str]], max_depth: int = 20
+) -> None:
+    """Append conversation pairs to buyer history in Firestore."""
+    if not buyer_name:
+        return
+
+    history = get_history(buyer_name)
+    for role, text in pairs:
+        entry = {"role": role, "text": text}
+        if entry not in history:
+            history.append(entry)
+    history = history[-max_depth:]
+
+    payload = {
+        "fields": {
+            "conversation": {
+                "stringValue": json.dumps(history, ensure_ascii=False)
+            }
+        }
+    }
+    body = json.dumps(payload).encode("utf-8")
+
+    doc_id = _doc_id(buyer_name)
+    patch_url = (
+        f"{BASE_URL}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
+        f"{COLLECTION}/{doc_id}?key={FIREBASE_CONFIG['apiKey']}"
+    )
+    req = Request(
+        patch_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="PATCH",
+    )
+    try:
+        with urlopen(req) as resp:
+            resp.read()
+        return
+    except Exception:
+        pass
+
+    create_url = (
+        f"{BASE_URL}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
+        f"{COLLECTION}?documentId={doc_id}&key={FIREBASE_CONFIG['apiKey']}"
+    )
+    req = Request(create_url, data=body, headers={"Content-Type": "application/json"})
+    try:
+        with urlopen(req) as resp:
+            resp.read()
+    except Exception:
+        pass
+


### PR DESCRIPTION
## Summary
- store per-buyer conversation history in Firestore `history` collection
- resume chats using saved history and append new replies automatically

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68af38415288832ab488510be36bcf98