### PR TITLE
feat: classify conversation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ O bot vai:
 2) (Opcional) Aplicar o filtro “Precisa responder”
 3) Iterar pelas conversas listadas
 4) Ler as **últimas N mensagens** (configurável)
-5) Perguntar ao **Gemini** qual a intenção e **se deve responder** (lembrando das suas regras)
+5) Classificar a conversa com o **Gemini** (intenção, estado, sentimento e urgência) e decidir se responde
 6) Montar resposta a partir dos **templates** e **enviar**
 7) Registrar logs no console
 
@@ -79,6 +79,7 @@ Por padrão, roda uma varredura a cada 120 segundos (config em `.env`).
 - Elogios/recebido → agradecer e se colocar à disposição.
 - Dúvidas comuns (envio/rastreio) → templates FAQ.
 - Permite **inserir código de rastreio** caso esteja visível (depende dos seletores e do layout atual).
+- Detecta o **estado da conversa** (pré-venda, pós-venda, pagamento, etc.) para ajustar tom e próxima ação.
 
 ## Exportar histórico de conversas
 

--- a/app_ui.py
+++ b/app_ui.py
@@ -844,12 +844,13 @@ async def _run_cycle(run_once: bool):
                 }
             }
         )
-        should, reply = decide_reply(pairs, buyer_only, order_info)
+        should, reply, info = decide_reply(pairs, buyer_only, order_info)
         ws_broadcast(
             {
                 "snapshot": {
                     "reading": [list(p) for p in pairs],
                     "proposed": reply,
+                    "estado": info.get("estado") if info else None,
                     "running": True,
                 }
             }

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 from typing import List, Tuple
 import re
 
-from .gemini_client import generate_reply
+from .gemini_client import generate_reply, classify_conversation
 from .config import settings
 from .firebase_client import get_product_by_sku
+from .state_machine import ConversationStateMachine
 
 RESP_FALLBACK_CURTO = "Desculpe, não entendi muito bem sua mensagem. Você poderia explicar um pouco melhor para que eu consiga te ajudar?"
 
@@ -55,12 +56,22 @@ def intent_from_text(txt: str) -> str:
     return "fallback"
 
 
+# Estado por conversa (simples memória em processo)
+_STATE_MACHINES: dict[str, ConversationStateMachine] = {}
+
+
 def decide_reply(
     pairs: List[Tuple[str, str]],
     buyer_only: List[str],
     order_info: dict | None = None,
-) -> Tuple[bool, str]:
-    """Decide se deve responder e retorna o rascunho (somente últimas N do comprador)."""
+) -> Tuple[bool, str, dict]:
+    """Decide se deve responder e retorna o rascunho + metadados.
+
+    O terceiro elemento do retorno contém o dicionário com
+    ``{intent, estado, sentimento, urgencia}`` obtido pelo classificador do
+    Gemini. Esse dicionário também mantém o estado da conversa via uma pequena
+    máquina de estados em memória.
+    """
     depth = int(getattr(settings, "history_depth", 15) or 15)
 
     msgs = [m for m in (buyer_only or []) if m and m.strip()][-depth:]
@@ -70,6 +81,15 @@ def decide_reply(
     history = order_info.get("history_block") if order_info else None
     if not history:
         history = "\n".join(msgs)
+
+    # Analisa intenção/estado com Gemini
+    analysis = classify_conversation(history)
+
+    # Atualiza state machine por conversa (usa orderId ou nome do comprador)
+    key = (order_info or {}).get("orderId") or (order_info or {}).get("buyer_name") or "_"
+    machine = _STATE_MACHINES.setdefault(key, ConversationStateMachine())
+    machine.update(analysis.get("estado", machine.state.value))
+    analysis["estado"] = machine.state.value
 
     # Busca dados do produto pelo SKU e injeta em order_info
     sku = order_info.get("sku") if order_info else None
@@ -82,8 +102,8 @@ def decide_reply(
     # exemplo de uso do classificador regex (opcional)
     _ = intent_from_text(" ".join(msgs))
 
-    reply = generate_reply(history, order_info=order_info)
+    reply = generate_reply(history, order_info=order_info, analysis=analysis)
     clean = _sanitize_reply(reply)
     if clean:
-        return True, clean
-    return False, ""
+        return True, clean, analysis
+    return False, "", analysis

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -1124,7 +1124,17 @@ class DuokeBot:
                     result = decide_reply_fn(buyer_only)
                 if inspect.isawaitable(result):
                     result = await result
-                should, reply = result
+                if isinstance(result, tuple):
+                    if len(result) == 3:
+                        should, reply, _meta = result
+                        if _meta:
+                            print(f"[DEBUG] analise: {_meta}")
+                    else:
+                        should, reply = result
+                        _meta = None
+                else:
+                    should, reply = bool(result), ""
+                    _meta = None
             except Exception as e:
                 print(f"[DEBUG] erro no hook/classificador: {e}")
                 should, reply = True, RESP_FALLBACK_CURTO

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -3,6 +3,7 @@ import google.generativeai as genai
 from .config import settings
 from .firebase_client import get_product_by_sku
 import json
+import re
 from typing import Any, Dict
 
 
@@ -42,6 +43,35 @@ def send_product_payload(produto: Dict[str, Any], contexto: str, objetivo: str) 
         return (getattr(resp, "text", "") or "").strip()
     except Exception:
         return ""
+
+
+def classify_conversation(history: str) -> Dict[str, str]:
+    """Classifica uma conversa retornando {intent, estado, sentimento, urgencia}.
+
+    Usa o Gemini para produzir um JSON estruturado. Em caso de falha ou chave
+    ausente, devolve dicionário vazio.
+    """
+
+    if not settings.gemini_api_key:
+        return {}
+    model = get_gemini()
+    prompt = (
+        "Classifique a conversa abaixo retornando um JSON com as chaves"
+        " intent, estado, sentimento e urgencia.\n"
+        "Estados possíveis: pre_venda, pos_venda_sem_problema, pos_venda_problema,"
+        " pagamento/checkout, silencio_do_cliente, encerrado.\n\n"
+        f"Conversa:\n{history}"
+    )
+    try:
+        resp = model.generate_content(prompt)
+        txt = (getattr(resp, "text", "") or "").strip()
+        # Tenta extrair o primeiro bloco JSON da resposta
+        m = re.search(r"\{.*\}", txt, re.S)
+        if m:
+            return json.loads(m.group(0))
+        return json.loads(txt)
+    except Exception:
+        return {}
 
 
 def _order_stage_context(order_info: dict | None) -> str:
@@ -115,9 +145,15 @@ def _order_stage_context(order_info: dict | None) -> str:
     )
 
 
-def generate_reply(history: str, order_info: dict | None = None) -> str:
-    """Gera resposta direta com base nas últimas mensagens + contexto do pedido.
+def generate_reply(
+    history: str,
+    order_info: dict | None = None,
+    analysis: Dict[str, str] | None = None,
+) -> str:
+    """Gera resposta direta com base nas últimas mensagens + contexto.
 
+    ``analysis`` pode conter metadados retornados por ``classify_conversation``
+    (intent, estado, sentimento, urgencia) para orientar o tom da resposta.
     Também garante que, se houver um SKU disponível, os dados do produto
     correspondente sejam recuperados do sistema de produtos e enviados como
     contexto ao Gemini."""
@@ -134,6 +170,15 @@ def generate_reply(history: str, order_info: dict | None = None) -> str:
 
         model = get_gemini()
         contexto = _order_stage_context(order_info)
+        analysis_context = ""
+        if analysis:
+            analysis_context = (
+                "[Analise da Conversa]\n"
+                f"intent: {analysis.get('intent', '')}\n"
+                f"estado: {analysis.get('estado', '')}\n"
+                f"sentimento: {analysis.get('sentimento', '')}\n"
+                f"urgencia: {analysis.get('urgencia', '')}\n\n"
+            )
         prod = order_info.get("product_info") if order_info else None
         prod_context = ""
         if prod:
@@ -153,7 +198,7 @@ INSTRUÇÕES ADICIONAIS (NÃO MOSTRAR AO CLIENTE):
 - Se a política for "pular" (ex.: pix/comprovante), devolva APENAS: "Ação: skip (pular)".
 - Caso contrário, devolva APENAS a mensagem final em 1–2 frases (sem "ID:", sem "Resposta:", sem análises).
 
-{prod_context}[Contexto do Pedido]
+{analysis_context}{prod_context}[Contexto do Pedido]
 {contexto}
 
 [Conversa]

--- a/src/run_once.py
+++ b/src/run_once.py
@@ -21,8 +21,8 @@ async def main():
         print("[DEBUG] Mensagens recebidas para classificação:")
         for role, msg in pairs:
             print(f"- {role}: {msg}")
-        should, reply = decide_reply(pairs, buyer_only, order_info)
-        print(f"[DEBUG] Deve responder? {should} | Resposta: {reply}")
+        should, reply, info = decide_reply(pairs, buyer_only, order_info)
+        print(f"[DEBUG] Deve responder? {should} | Estado: {info.get('estado')} | Resposta: {reply}")
         return should, reply
 
     await bot.run_once(debug_reply)

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Conversation state machine utilities.
+
+This module defines the states used by the bot to track each conversation and
+provides helpers to update the state in a controlled manner. The machine is
+simple but allows future expansion.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Iterable
+
+
+class ConversationState(str, Enum):
+    """Possible stages of a conversation."""
+
+    PRE_VENDA = "pre_venda"
+    POS_VENDA_SEM_PROBLEMA = "pos_venda_sem_problema"
+    POS_VENDA_PROBLEMA = "pos_venda_problema"
+    PAGAMENTO_CHECKOUT = "pagamento/checkout"
+    SILENCIO_DO_CLIENTE = "silencio_do_cliente"
+    ENCERRADO = "encerrado"
+
+
+# Allowed transitions between states. The machine is conservative: if a
+# transition is not listed, the current state is preserved.
+TRANSITIONS: Dict[ConversationState, Iterable[ConversationState]] = {
+    ConversationState.PRE_VENDA: {
+        ConversationState.PAGAMENTO_CHECKOUT,
+        ConversationState.POS_VENDA_SEM_PROBLEMA,
+        ConversationState.POS_VENDA_PROBLEMA,
+    },
+    ConversationState.POS_VENDA_SEM_PROBLEMA: {
+        ConversationState.POS_VENDA_PROBLEMA,
+        ConversationState.ENCERRADO,
+    },
+    ConversationState.POS_VENDA_PROBLEMA: {
+        ConversationState.POS_VENDA_SEM_PROBLEMA,
+        ConversationState.ENCERRADO,
+    },
+    ConversationState.PAGAMENTO_CHECKOUT: {
+        ConversationState.POS_VENDA_SEM_PROBLEMA,
+        ConversationState.SILENCIO_DO_CLIENTE,
+    },
+    ConversationState.SILENCIO_DO_CLIENTE: {
+        ConversationState.POS_VENDA_SEM_PROBLEMA,
+        ConversationState.ENCERRADO,
+    },
+    ConversationState.ENCERRADO: set(),
+}
+
+
+def transition_state(
+    current: ConversationState, desired: ConversationState
+) -> ConversationState:
+    """Return the next state given a desired target.
+
+    If the transition is not explicitly allowed, ``current`` is returned.
+    """
+
+    allowed = TRANSITIONS.get(current, set())
+    if desired == current or desired in allowed:
+        return desired
+    return current
+
+
+@dataclass
+class ConversationStateMachine:
+    """Small helper to keep track of a conversation state."""
+
+    state: ConversationState = ConversationState.PRE_VENDA
+
+    def update(self, desired: str | ConversationState) -> ConversationState:
+        try:
+            desired_state = (
+                desired
+                if isinstance(desired, ConversationState)
+                else ConversationState(desired)
+            )
+        except ValueError:
+            # Unknown state → keep current
+            return self.state
+        self.state = transition_state(self.state, desired_state)
+        return self.state


### PR DESCRIPTION
## Summary
- add conversation state machine and transitions
- classify conversations with Gemini to extract intent, state, sentiment and urgency
- inject classification metadata into reply generation

## Testing
- `python -m py_compile src/state_machine.py src/gemini_client.py src/classifier.py src/duoke.py src/run_once.py app_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0435073a8832ab76b754da88a6532