### PR TITLE
Ensure bot replies to every open conversation

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -556,13 +556,27 @@ class DuokeBot:
     async def show_all_conversations(self, page):
         """Garante que todas as conversas estejam visíveis, removendo filtros como 'Precisa responder'."""
         try:
-            sel = SEL.get("filter_all_conversations", "")
-            if not sel:
+            sel_all = SEL.get("filter_all_conversations", "")
+            if sel_all:
+                locator = page.locator(sel_all)
+                if await locator.count() > 0:
+                    await locator.first.click()
+                    await page.wait_for_timeout(1000)
+                    return
+        except Exception:
+            pass
+        # fallback: se não houver opção explícita de "Todos", tenta desativar
+        # diretamente o filtro "Precisa responder" caso ele esteja ativo
+        try:
+            sel_needs = SEL.get("filter_needs_reply", "")
+            if not sel_needs:
                 return
-            locator = page.locator(sel)
+            locator = page.locator(sel_needs)
             if await locator.count() > 0:
-                await locator.first.click()
-                await page.wait_for_timeout(1000)
+                cls = (await locator.first.get_attribute("class") or "").lower()
+                if any(flag in cls for flag in ("active", "checked", "is-active")):
+                    await locator.first.click()
+                    await page.wait_for_timeout(1000)
         except Exception:
             # Não deve interromper o fluxo se o seletor não existir ou falhar
             pass


### PR DESCRIPTION
## Summary
- Expand `show_all_conversations` to disable the "Precisa responder" filter when active so the bot can see chats even if the last message was from the seller

## Testing
- `python -m py_compile src/duoke.py`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05b257628832a976ebb5c77e118fa