### PR TITLE
Export history to Excel from Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Por padrão, roda uma varredura a cada 120 segundos (config em `.env`).
 ## Exportar histórico de conversas
 
 A interface web possui um botão **Exportar histórico** na aba *Atendimentos* que permite
-baixar o arquivo `history.json` com todas as mensagens salvas pelo bot.
+baixar um arquivo `history.xlsx` com todas as mensagens salvas pelo bot organizadas em colunas.
 
 ## Estrutura
 

--- a/app_ui.py
+++ b/app_ui.py
@@ -32,6 +32,7 @@ from src.config import settings
 from src.classifier import decide_reply
 from src.rules import load_rules, save_rules
 from src.cases import export_to_excel
+from src.history import export_history_to_excel
 from playwright.async_api import TimeoutError as PWTimeoutError
 
 # ===== Estado global simples =====
@@ -545,10 +546,14 @@ async def export_cases_xlsx():
 
 @app.get("/export-history")
 async def export_history():
-    p = Path("data/history.json")
-    if not p.exists():
+    p = export_history_to_excel()
+    if not p:
         return JSONResponse({"ok": False, "error": "Nenhum histórico ainda."}, status_code=404)
-    return FileResponse(str(p), media_type="application/json", filename="history.json")
+    return FileResponse(
+        str(p),
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        filename="history.xlsx",
+    )
 
 
 # Monta /static somente se a pasta existir (evita erro em ambientes sem assets)

--- a/src/history.py
+++ b/src/history.py
@@ -10,8 +10,11 @@ message.
 from __future__ import annotations
 
 import json
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from urllib.request import Request, urlopen
+from pathlib import Path
+
+from openpyxl import Workbook
 
 from .firebase_client import FIREBASE_CONFIG
 
@@ -102,4 +105,46 @@ def append_history(
             resp.read()
     except Exception:
         pass
+
+
+def export_history_to_excel() -> Optional[Path]:
+    """Export all conversation history documents to an Excel file."""
+
+    url = (
+        f"{BASE_URL}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
+        f"history?key={FIREBASE_CONFIG['apiKey']}"
+    )
+    try:
+        with urlopen(url) as resp:
+            data = json.load(resp)
+    except Exception:
+        return None
+
+    docs = data.get("documents", [])
+    if not docs:
+        return None
+
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["buyer_name", "role", "text"])
+
+    for doc in docs:
+        doc_name = doc.get("name", "")
+        buyer = doc_name.split("/")[-1].replace("_", "/")
+        messages = (
+            doc.get("fields", {})
+            .get("messages", {})
+            .get("arrayValue", {})
+            .get("values", [])
+        )
+        for msg in messages:
+            fields = msg.get("mapValue", {}).get("fields", {})
+            role = fields.get("role", {}).get("stringValue", "")
+            text = fields.get("text", {}).get("stringValue", "")
+            ws.append([buyer, role, text])
+
+    path = Path("data/history.xlsx")
+    path.parent.mkdir(exist_ok=True)
+    wb.save(path)
+    return path
 


### PR DESCRIPTION
## Summary
- add utility to fetch conversation history from Firestore and generate Excel
- serve Excel file in `/export-history` endpoint
- document Excel history export in README

## Testing
- `python -m py_compile src/history.py app_ui.py`
- `python - <<'PY'
from src.history import export_history_to_excel
print(export_history_to_excel())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b08aca321c832abf21973f8fc89a33