### PR TITLE
feat: ensure structured gemini responses

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -4,38 +4,11 @@ from __future__ import annotations
 from typing import List, Tuple
 import re
 
-from .gemini_client import generate_reply
+from .gemini_client import generate_reply, validate_reply_text
 from .config import settings
 from .firebase_client import get_product_by_sku
 
 RESP_FALLBACK_CURTO = "Desculpe, não entendi muito bem sua mensagem. Você poderia explicar um pouco melhor para que eu consiga te ajudar?"
-
-
-def _sanitize_reply(text: str) -> str:
-    if not text:
-        return ""
-    t = text.strip()
-
-    # Se vier "Ação: skip (pular)" ou variações, devolve vazio
-    low = t.lower()
-    if (
-        low == "skip"
-        or "ação: skip" in low
-        or "acao: skip" in low
-        or "skip (pular)" in low
-    ):
-        return ""
-
-    # Remove rótulos tipo "ID:" e extrai só o conteúdo após "Resposta:"
-    t = re.sub(r"(?is)\bID:\s*.*?$", "", t).strip()
-    m = re.search(r'(?is)\bResposta:\s*"(.*?)"\s*$', t)
-    if m:
-        return m.group(1).strip()
-    m2 = re.search(r"(?is)\bResposta:\s*(.+)$", t)
-    if m2:
-        return m2.group(1).strip()
-
-    return t
 
 
 ARCO = re.compile(
@@ -82,8 +55,18 @@ def decide_reply(
     # exemplo de uso do classificador regex (opcional)
     _ = intent_from_text(" ".join(msgs))
 
-    reply = generate_reply(history, order_info=order_info)
-    clean = _sanitize_reply(reply)
-    if clean:
-        return True, clean
-    return False, ""
+    resp = generate_reply(history, order_info=order_info)
+    if not resp:
+        return False, ""
+    if resp.action != "reply":
+        return False, ""
+    if resp.confidence < settings.reply_confidence_threshold:
+        return False, ""
+    if not (
+        resp.policy_flags.nao_altera_endereco
+        and resp.policy_flags.nao_cobra_fora_app
+    ):
+        return False, ""
+    if not validate_reply_text(resp.reply):
+        return False, ""
+    return True, resp.reply

--- a/src/config.py
+++ b/src/config.py
@@ -43,6 +43,11 @@ class Settings(BaseModel):
     refine_max_chars: int = Field(
         default_factory=lambda: int(os.getenv("REFINE_MAX_CHARS", "0"))
     )
+    reply_confidence_threshold: float = Field(
+        default_factory=lambda: float(
+            os.getenv("REPLY_CONFIDENCE_THRESHOLD", "0.6")
+        )
+    )
 
     # --- App / Robô ---
     douke_url: str = Field(

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -3,7 +3,63 @@ import google.generativeai as genai
 from .config import settings
 from .firebase_client import get_product_by_sku
 import json
-from typing import Any, Dict
+import re
+from typing import Any, Dict, Literal
+from pydantic import BaseModel, Field, ValidationError
+
+
+class Entities(BaseModel):
+    sku: str = ""
+    pedido: str = ""
+    produto: str = ""
+    medida: str = ""
+
+
+class PolicyFlags(BaseModel):
+    nao_altera_endereco: bool = True
+    nao_cobra_fora_app: bool = True
+
+
+class GeminiResponse(BaseModel):
+    action: Literal["reply", "skip", "ask_clarifying", "escalate"]
+    reply: str
+    intent: str
+    confidence: float
+    entities: Entities = Field(default_factory=Entities)
+    policy_flags: PolicyFlags = Field(default_factory=PolicyFlags)
+    reasons: list[str] = Field(default_factory=list)
+
+
+ADDRESS_RE = re.compile(
+    r"\b(rua|avenida|av\\.?|estrada|bairro|cep|logradouro|end(?:ereç|ereco))\b",
+    re.I,
+)
+OFF_APP_RE = re.compile(
+    r"\b(pix|transfer[êe]ncia|dep[óo]sito|whatsapp|zap|telefone|tel\\.?|boleto|chave)\b",
+    re.I,
+)
+
+
+def validate_reply_text(text: str) -> bool:
+    low = (text or "").lower()
+    if ADDRESS_RE.search(low):
+        return False
+    if OFF_APP_RE.search(low):
+        return False
+    return True
+
+
+JSON_CONTRACT = (
+    "{\n"
+    '  "action":"reply|skip|ask_clarifying|escalate",\n'
+    '  "reply":"...",\n'
+    '  "intent":"medidas|endereco|peca_faltando|reembolso_parcial|pos_venda|...",\n'
+    '  "confidence": 0.0,\n'
+    '  "entities": {"sku":"","pedido":"","produto":"","medida":""},\n'
+    '  "policy_flags":{"nao_altera_endereco":true,"nao_cobra_fora_app":true},\n'
+    '  "reasons":["...","..."]\n'
+    "}"
+)
 
 
 def get_gemini():
@@ -115,14 +171,10 @@ def _order_stage_context(order_info: dict | None) -> str:
     )
 
 
-def generate_reply(history: str, order_info: dict | None = None) -> str:
-    """Gera resposta direta com base nas últimas mensagens + contexto do pedido.
-
-    Também garante que, se houver um SKU disponível, os dados do produto
-    correspondente sejam recuperados do sistema de produtos e enviados como
-    contexto ao Gemini."""
+def generate_reply(history: str, order_info: dict | None = None) -> GeminiResponse | None:
+    """Gera resposta estruturada com base nas últimas mensagens e contexto do pedido."""
     if not settings.gemini_api_key:
-        return ""
+        return None
     try:
         if order_info and not order_info.get("product_info"):
             sku = order_info.get("sku")
@@ -151,29 +203,21 @@ INSTRUÇÕES ADICIONAIS (NÃO MOSTRAR AO CLIENTE):
 - Use o contexto do pedido abaixo para entender se é pré-venda, pós-venda, enviado ou entregue.
 - Se estado_pedido for "enviado" ou "entregue", **não** use o template de tempo_envio. Se perguntarem prazo, peça UM esclarecimento objetivo (ex.: “é para este pedido ou um novo?”) sem citar status/rastreio.
 - Se a política for "pular" (ex.: pix/comprovante), devolva APENAS: "Ação: skip (pular)".
-- Caso contrário, devolva APENAS a mensagem final em 1–2 frases (sem "ID:", sem "Resposta:", sem análises).
+- Caso contrário, responda usando APENAS o JSON com o schema abaixo.
 
 {prod_context}[Contexto do Pedido]
 {contexto}
 
 [Conversa]
 {history}
+
+Responda APENAS com um JSON seguindo este schema:
+{JSON_CONTRACT}
 """.strip()
 
         resp = model.generate_content(prompt)
         text = (getattr(resp, "text", "") or "").strip()
-
-        # Higienização: remover aspas externas e evitar "Ação:" indevida
-        if (text.startswith('"') and text.endswith('"')) or (
-            text.startswith("'") and text.endswith("'")
-        ):
-            text = text[1:-1].strip()
-
-        low = text.lower()
-        if low.startswith("ação:") and "skip" not in low:
-            # Não permitir outras "ações" além de skip
-            text = text.replace("Ação:", "").strip()
-
-        return text
-    except Exception:
-        return ""
+        data = json.loads(text)
+        return GeminiResponse.model_validate(data)
+    except (json.JSONDecodeError, ValidationError, Exception):
+        return None


### PR DESCRIPTION
## Summary
- enforce structured JSON contract for Gemini replies
- validate policy flags and off-app patterns before replying
- gate replies behind configurable confidence threshold

## Testing
- `python -m py_compile src/gemini_client.py src/classifier.py src/config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0cdeb9d18832aaac85101c6d65898