### PR TITLE
Adiciona RAG leve com políticas oficiais

### DIFF
--- a/policies/nao_altera_endereco.md
+++ b/policies/nao_altera_endereco.md
@@ -1,0 +1,2 @@
+**Alteração de endereço**
+Por segurança, não fazemos alterações de endereço após a compra. Se precisar alterar, cancele e refaça o pedido com os dados corretos.

--- a/policies/nao_cobra_fora_app.md
+++ b/policies/nao_cobra_fora_app.md
@@ -1,0 +1,2 @@
+**Cobrança fora do app**
+A Shopee nunca solicita pagamentos fora do aplicativo. Qualquer cobrança deve ser feita apenas dentro da plataforma oficial.

--- a/policies/reembolso.md
+++ b/policies/reembolso.md
@@ -1,0 +1,2 @@
+**Reembolso**
+Para solicitar reembolso, use o app: Minhas Compras > pedido > Devolver/Reembolsar. Anexe fotos e descrição do problema para agilizar a análise.

--- a/policies/tabela_medidas.md
+++ b/policies/tabela_medidas.md
@@ -1,0 +1,2 @@
+**Tabela de medidas**
+Confira a tabela de medidas disponível no anúncio para saber as dimensões exatas de cada modelo antes de comprar.

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -5,6 +5,7 @@ from typing import List, Tuple
 import re
 
 from .gemini_client import generate_reply, validate_reply_text
+from .policies import detect_policies, load_snippets
 from .config import settings
 from .firebase_client import get_product_by_sku
 
@@ -55,7 +56,10 @@ def decide_reply(
     # exemplo de uso do classificador regex (opcional)
     _ = intent_from_text(" ".join(msgs))
 
-    resp = generate_reply(history, order_info=order_info)
+    policy_ids = detect_policies(" ".join(msgs))
+    policy_block = load_snippets(policy_ids)
+
+    resp = generate_reply(history, order_info=order_info, policy_context=policy_block)
     if not resp:
         return False, ""
     if resp.action != "reply":

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -171,8 +171,15 @@ def _order_stage_context(order_info: dict | None) -> str:
     )
 
 
-def generate_reply(history: str, order_info: dict | None = None) -> GeminiResponse | None:
-    """Gera resposta estruturada com base nas últimas mensagens e contexto do pedido."""
+def generate_reply(
+    history: str,
+    order_info: dict | None = None,
+    policy_context: str = "",
+) -> GeminiResponse | None:
+    """Gera resposta estruturada com base nas últimas mensagens e contexto do pedido.
+
+    `policy_context` pode incluir trechos oficiais que devem ser considerados pelo modelo.
+    """
     if not settings.gemini_api_key:
         return None
     try:
@@ -198,8 +205,7 @@ def generate_reply(history: str, order_info: dict | None = None) -> GeminiRespon
             )
 
         prompt = f"""{settings.base_prompt}
-
-INSTRUÇÕES ADICIONAIS (NÃO MOSTRAR AO CLIENTE):
+{policy_context}INSTRUÇÕES ADICIONAIS (NÃO MOSTRAR AO CLIENTE):
 - Use o contexto do pedido abaixo para entender se é pré-venda, pós-venda, enviado ou entregue.
 - Se estado_pedido for "enviado" ou "entregue", **não** use o template de tempo_envio. Se perguntarem prazo, peça UM esclarecimento objetivo (ex.: “é para este pedido ou um novo?”) sem citar status/rastreio.
 - Se a política for "pular" (ex.: pix/comprovante), devolva APENAS: "Ação: skip (pular)".

--- a/src/policies.py
+++ b/src/policies.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from pathlib import Path
+import re
+
+POLICY_DIR = Path(__file__).resolve().parent.parent / "policies"
+
+POLICY_FILES = {
+    "nao_altera_endereco": POLICY_DIR / "nao_altera_endereco.md",
+    "nao_cobra_fora_app": POLICY_DIR / "nao_cobra_fora_app.md",
+    "reembolso": POLICY_DIR / "reembolso.md",
+    "tabela_medidas": POLICY_DIR / "tabela_medidas.md",
+}
+
+ENDERECO_RE = re.compile(r"\bendere[cç]o\b|\balterar endereco\b|\bmudar endereco\b", re.I)
+OFF_APP_RE = re.compile(r"\b(pix|transfer[êe]ncia|dep[oó]sito|boleto|chave|whatsapp|zap)\b", re.I)
+REEMBOLSO_RE = re.compile(r"\breembolso\b|\bdevolu[cç][aã]o\b|\bdevolver\b", re.I)
+MEDIDAS_RE = re.compile(r"\bmedidas?\b|\btamanho\b|\btabela de medidas\b", re.I)
+
+
+def detect_policies(text: str) -> list[str]:
+    """Retorna lista de IDs de políticas com base no texto do cliente."""
+    policies: list[str] = []
+    if ENDERECO_RE.search(text):
+        policies.append("nao_altera_endereco")
+    if OFF_APP_RE.search(text):
+        policies.append("nao_cobra_fora_app")
+    if REEMBOLSO_RE.search(text):
+        policies.append("reembolso")
+    if MEDIDAS_RE.search(text):
+        policies.append("tabela_medidas")
+    return policies
+
+
+def load_snippets(policy_ids: list[str]) -> str:
+    """Lê os arquivos das políticas e monta o bloco de contexto."""
+    snippets = []
+    for pid in policy_ids:
+        path = POLICY_FILES.get(pid)
+        if path and path.exists():
+            snippets.append(path.read_text(encoding="utf-8").strip())
+    if snippets:
+        return "[Políticas/Respostas Oficiais]\n" + "\n\n".join(snippets) + "\n\n"
+    return ""


### PR DESCRIPTION
## Resumo
- Inclui documentos curtos de políticas oficiais (endereço, cobranças fora do app, reembolso e tabela de medidas)
- Cria módulo de detecção/carregamento e injeta trechos oficiais no prompt
- Ajusta geração no Gemini para receber bloco `Políticas/Respostas Oficiais`

## Testes
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b0db616afc832a9a6bb58ae0e2ba96