### PR TITLE
Implement conversation memory, summary, and caching

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 from typing import List, Tuple
 import re
 
-from .gemini_client import generate_reply, validate_reply_text
+from .gemini_client import (
+    generate_reply,
+    validate_reply_text,
+    detect_order_stage,
+)
 from .policies import detect_policies, load_snippets
 from .config import settings
 from .firebase_client import get_product_by_sku
+from .semantic_cache import get_cached_reply, store_cached_reply
 
 RESP_FALLBACK_CURTO = "Desculpe, não entendi muito bem sua mensagem. Você poderia explicar um pouco melhor para que eu consiga te ajudar?"
 
@@ -41,6 +46,13 @@ def decide_reply(
     if not msgs:
         return False, ""
 
+    last_msg = msgs[-1]
+    etapa = detect_order_stage(order_info) if order_info else "desconhecido"
+    intent_guess = intent_from_text(" ".join(msgs))
+    cached = get_cached_reply(last_msg, etapa, intent_guess)
+    if cached and validate_reply_text(cached):
+        return True, cached
+
     history = order_info.get("history_block") if order_info else None
     if not history:
         history = "\n".join(msgs)
@@ -52,9 +64,6 @@ def decide_reply(
         if prod:
             order_info = dict(order_info or {})
             order_info["product_info"] = prod
-
-    # exemplo de uso do classificador regex (opcional)
-    _ = intent_from_text(" ".join(msgs))
 
     policy_ids = detect_policies(" ".join(msgs))
     policy_block = load_snippets(policy_ids)
@@ -73,4 +82,20 @@ def decide_reply(
         return False, ""
     if not validate_reply_text(resp.reply):
         return False, ""
+
+    # Atualiza slots inferidos pelo modelo
+    if order_info is not None:
+        order_info.setdefault("etapa", etapa)
+        ent = resp.entities
+        if ent.sku and not order_info.get("sku"):
+            prod = get_product_by_sku(ent.sku)
+            if prod:
+                order_info["sku"] = ent.sku
+                order_info["product_info"] = prod
+        if ent.pedido and not order_info.get("pedido"):
+            order_info["pedido"] = ent.pedido
+        if ent.produto and not order_info.get("produto"):
+            order_info["produto"] = ent.produto
+
+    store_cached_reply(last_msg, etapa, resp.intent, resp.reply)
     return True, resp.reply

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -20,7 +20,7 @@ from .cases import (
     append_label as log_label,
     infer_problema,
 )
-from .history import get_history, append_history
+from .history import get_history_with_summary, append_history, update_context
 from .product_cards import detect_product_cards
 
 # Carrega seletores configuráveis
@@ -976,18 +976,20 @@ class DuokeBot:
                 return ""
 
     @staticmethod
-    def build_history_from_pairs(pairs, max_depth: int = 20):
+    def build_history_from_pairs(pairs, summary: str = "", max_depth: int = 20):
         """Monta histórico rotulado com mensagens de comprador e vendedor.
 
-        pairs: lista [(role, text)] em ordem cronológica.
+        ``pairs``: lista ``[(role, text)]`` em ordem cronológica.
+        ``summary``: TL;DR factual do histórico (se disponível).
         Retorna bloco de texto com as últimas ``max_depth`` mensagens, cada
-        uma precedida por ``Comprador:`` ou ``Vendedor:`` para indicar a
-        origem. Essas informações são enviadas ao Gemini como contexto da
-        conversa.
+        uma precedida por ``Comprador:`` ou ``Vendedor`` para indicar a origem.
+        Essas informações são enviadas ao Gemini como contexto da conversa.
         """
 
         recents = pairs[-max_depth:]
         lines: list[str] = []
+        if summary:
+            lines.append(f"Conversation Summary: {summary.strip()}")
         for role, text in recents:
             prefix = "Comprador" if role == "buyer" else "Vendedor"
             lines.append(f"{prefix}: {text.strip()}")
@@ -1049,8 +1051,9 @@ class DuokeBot:
                 continue
 
             buyer_name = (order_info.get("buyer_name") or "").strip()
+            summary = ""
             if buyer_name:
-                stored = get_history(buyer_name)
+                stored, summary = get_history_with_summary(buyer_name)
                 if stored:
                     for p in pairs:
                         if p not in stored:
@@ -1086,7 +1089,7 @@ class DuokeBot:
                     continue
 
             # Últimas mensagens de comprador e vendedor para contexto
-            history_block = self.build_history_from_pairs(pairs, max_depth=depth * 2)
+            history_block = self.build_history_from_pairs(pairs, summary, max_depth=depth * 2)
             order_info["history_block"] = history_block
 
             # ----- dedupe por conversa e rate-limit -----
@@ -1157,6 +1160,17 @@ class DuokeBot:
             self.last_replied_at[conv_key] = now
             if buyer_name:
                 append_history(buyer_name, pairs + [("seller", reply)], max_depth=depth * 2)
+                context_data = {
+                    "pedido": order_info.get("orderId")
+                    or order_info.get("pedido", ""),
+                    "sku": order_info.get("sku", ""),
+                    "produto": order_info.get("title")
+                    or order_info.get("produto", ""),
+                    "status_logistico": order_info.get("logistics_status")
+                    or order_info.get("status", ""),
+                    "etapa": order_info.get("etapa", ""),
+                }
+                update_context(buyer_name, context_data)
 
             await page.wait_for_timeout(
                 int(getattr(settings, "delay_between_actions", 1.0) * 1000)

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -4,7 +4,7 @@ from .config import settings
 from .firebase_client import get_product_by_sku
 import json
 import re
-from typing import Any, Dict, Literal
+from typing import Any, Dict, Literal, List, Tuple
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -100,28 +100,17 @@ def send_product_payload(produto: Dict[str, Any], contexto: str, objetivo: str) 
         return ""
 
 
-def _order_stage_context(order_info: dict | None) -> str:
-    """Gera um pequeno resumo do estágio do pedido para orientar o modelo (NÃO exibir ao cliente)."""
-    # Default (sem info)
-    if not order_info:
-        return (
-            "estado_pedido: desconhecido\n"
-            "order_id:\n"
-            "status:\n"
-            "payment_time:\n"
-            "logistics_status:\n"
-            "latest_logistics_description:\n"
-            "completed_time:\n"
-        )
+def detect_order_stage(order_info: dict | None) -> str:
+    """Infer the order stage (pré-venda/pos-venda/enviado/entregue)."""
 
+    if not order_info:
+        return "desconhecido"
     st_raw = (
         order_info.get("status") or order_info.get("status_consolidado") or ""
     ).strip()
     st = st_raw.lower()
-
     fields = order_info.get("fields") or {}
     order_id = order_info.get("orderId") or ""
-
     payment_time = fields.get("Payment Time", "") or fields.get("Hora do pagamento", "")
     completed_time = fields.get("Completed Time", "") or fields.get(
         "Hora de conclusão", ""
@@ -133,7 +122,6 @@ def _order_stage_context(order_info: dict | None) -> str:
         "Latest Logistics Description", ""
     )
 
-    # Heurística de estágio
     shipped_tokens = (
         "shipped",
         "enviado",
@@ -159,6 +147,36 @@ def _order_stage_context(order_info: dict | None) -> str:
         fase = "pos_venda"
     else:
         fase = "pre_venda"
+    return fase
+
+
+def _order_stage_context(order_info: dict | None) -> str:
+    """Gera um pequeno resumo do estágio do pedido para orientar o modelo (NÃO exibir ao cliente)."""
+
+    fase = detect_order_stage(order_info)
+    if not order_info:
+        order_id = ""
+        st_raw = ""
+        payment_time = ""
+        logistics_status = ""
+        latest_desc = ""
+        completed_time = ""
+    else:
+        st_raw = (
+            order_info.get("status") or order_info.get("status_consolidado") or ""
+        ).strip()
+        fields = order_info.get("fields") or {}
+        order_id = order_info.get("orderId") or ""
+        payment_time = fields.get("Payment Time", "") or fields.get("Hora do pagamento", "")
+        completed_time = fields.get("Completed Time", "") or fields.get(
+            "Hora de conclusão", ""
+        )
+        logistics_status = fields.get("Logistics Status", "") or fields.get(
+            "Status logístico", ""
+        )
+        latest_desc = order_info.get("logistics_latest_desc", "") or fields.get(
+            "Latest Logistics Description", ""
+        )
 
     return (
         f"estado_pedido: {fase}\n"
@@ -227,3 +245,21 @@ Responda APENAS com um JSON seguindo este schema:
         return GeminiResponse.model_validate(data)
     except (json.JSONDecodeError, ValidationError, Exception):
         return None
+
+
+def summarize_history(pairs: List[Tuple[str, str]]) -> str:
+    """Generate a factual TL;DR summary of the conversation history."""
+
+    if not settings.gemini_api_key or not pairs:
+        return ""
+    model = get_gemini()
+    text = "\n".join(f"{r}: {t}" for r, t in pairs)
+    prompt = (
+        "Resuma de forma factual e sem opinião a conversa a seguir em até 60 palavras:\n\n"
+        + text
+    )
+    try:
+        resp = model.generate_content(prompt)
+        return (getattr(resp, "text", "") or "").strip()
+    except Exception:
+        return ""

--- a/src/history.py
+++ b/src/history.py
@@ -1,22 +1,27 @@
-"""Conversation history stored in Firestore.
+"""Conversation history stored in Firestore with additional context.
 
 This module replaces the previous local JSON storage and keeps a small
 conversation history for each buyer inside the Firebase collection
 ``history``.  Each document uses the buyer name as its document ID and
 contains an array field called ``messages`` with the role and text of each
-message.
+message.  Two extra fields are optionally stored:
+
+``summary`` – factual TL;DR of the conversation history; and
+``context`` – a map with slots about the order (pedido, sku, produto,
+``status_logistico`` and etapa).
 """
 
 from __future__ import annotations
 
 import json
-from typing import List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional
 from urllib.request import Request, urlopen
 from pathlib import Path
 
 from openpyxl import Workbook
 
 from .firebase_client import FIREBASE_CONFIG
+from .gemini_client import summarize_history
 
 
 BASE_URL = "https://firestore.googleapis.com/v1"
@@ -27,15 +32,11 @@ def _doc_id(name: str) -> str:
     return name.replace("/", "_")
 
 
-def get_history(buyer_name: str) -> List[Tuple[str, str]]:
-    """Return the stored conversation history for ``buyer_name``.
-
-    Each entry is returned as ``(role, text)``.  If the document does not
-    exist or any error occurs, an empty list is returned.
-    """
+def get_history_with_summary(buyer_name: str) -> Tuple[List[Tuple[str, str]], str]:
+    """Return the stored conversation history and summary for ``buyer_name``."""
 
     if not buyer_name:
-        return []
+        return [], ""
     doc_id = _doc_id(buyer_name)
     url = (
         f"{BASE_URL}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
@@ -56,24 +57,67 @@ def get_history(buyer_name: str) -> List[Tuple[str, str]]:
             role = f.get("role", {}).get("stringValue", "")
             text = f.get("text", {}).get("stringValue", "")
             out.append((role, text))
-        return out
+        summary = (
+            data.get("fields", {}).get("summary", {}).get("stringValue", "")
+        )
+        return out, summary
     except Exception:
-        return []
+        return [], ""
+
+
+def get_history(buyer_name: str) -> List[Tuple[str, str]]:
+    """Backward compatible helper returning only messages."""
+
+    msgs, _ = get_history_with_summary(buyer_name)
+    return msgs
+
+
+def get_context(buyer_name: str) -> Dict[str, str]:
+    """Return stored context slots for ``buyer_name``."""
+
+    if not buyer_name:
+        return {}
+    doc_id = _doc_id(buyer_name)
+    url = (
+        f"{BASE_URL}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
+        f"history/{doc_id}?key={FIREBASE_CONFIG['apiKey']}"
+    )
+    try:
+        with urlopen(url) as resp:
+            data = json.load(resp)
+        ctx_fields = (
+            data.get("fields", {}).get("context", {}).get("mapValue", {}).get("fields", {})
+        )
+        return {k: v.get("stringValue", "") for k, v in ctx_fields.items()}
+    except Exception:
+        return {}
 
 
 def append_history(
-    buyer_name: str, pairs: List[Tuple[str, str]], max_depth: int = 20
+    buyer_name: str,
+    pairs: List[Tuple[str, str]],
+    max_depth: int = 20,
+    summary_trigger: int = 40,
 ) -> None:
-    """Append conversation ``pairs`` to the buyer history in Firestore."""
+    """Append conversation ``pairs`` to the buyer history in Firestore.
+
+    If the message count exceeds ``summary_trigger`` a factual TL;DR is
+    generated and stored under the ``summary`` field.
+    """
 
     if not buyer_name:
         return
-    items = get_history(buyer_name)
+    items, summary = get_history_with_summary(buyer_name)
     for role, text in pairs:
         entry = (role, text)
         if entry not in items:
             items.append(entry)
     items = items[-max_depth:]
+
+    if len(items) >= summary_trigger:
+        new_summary = summarize_history(items)
+        if new_summary:
+            summary = new_summary
 
     doc_id = _doc_id(buyer_name)
     url = (
@@ -92,8 +136,36 @@ def append_history(
         }
         for role, text in items
     ]
-    data = {"fields": {"messages": {"arrayValue": {"values": values}}}}
+    data_fields = {"messages": {"arrayValue": {"values": values}}}
+    if summary:
+        data_fields["summary"] = {"stringValue": summary}
+    data = {"fields": data_fields}
 
+    req = Request(
+        url,
+        data=json.dumps(data).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="PATCH",
+    )
+    try:
+        with urlopen(req) as resp:
+            resp.read()
+    except Exception:
+        pass
+
+
+def update_context(buyer_name: str, context: Dict[str, str]) -> None:
+    """Update conversation context slots for ``buyer_name``."""
+
+    if not buyer_name or not context:
+        return
+    doc_id = _doc_id(buyer_name)
+    url = (
+        f"{BASE_URL}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
+        f"history/{doc_id}?key={FIREBASE_CONFIG['apiKey']}"
+    )
+    ctx_fields = {k: {"stringValue": v} for k, v in context.items()}
+    data = {"fields": {"context": {"mapValue": {"fields": ctx_fields}}}}
     req = Request(
         url,
         data=json.dumps(data).encode("utf-8"),

--- a/src/semantic_cache.py
+++ b/src/semantic_cache.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Simple in-memory semantic cache for responses."""
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import List
+
+
+@dataclass
+class CacheEntry:
+    message: str
+    etapa: str
+    intent: str
+    reply: str
+
+
+class SemanticCache:
+    def __init__(self) -> None:
+        self.entries: List[CacheEntry] = []
+
+    def get(self, message: str, etapa: str, intent: str, threshold: float = 0.9) -> str | None:
+        for ent in self.entries:
+            if ent.etapa == etapa and ent.intent == intent:
+                if SequenceMatcher(None, ent.message, message).ratio() >= threshold:
+                    return ent.reply
+        return None
+
+    def store(self, message: str, etapa: str, intent: str, reply: str, max_entries: int = 50) -> None:
+        if not (message and reply):
+            return
+        self.entries.append(CacheEntry(message, etapa, intent, reply))
+        if len(self.entries) > max_entries:
+            self.entries = self.entries[-max_entries:]
+
+
+_cache = SemanticCache()
+
+
+def get_cached_reply(message: str, etapa: str, intent: str) -> str | None:
+    return _cache.get(message, etapa, intent)
+
+
+def store_cached_reply(message: str, etapa: str, intent: str, reply: str) -> None:
+    _cache.store(message, etapa, intent, reply)


### PR DESCRIPTION
## Summary
- Track order context and conversation summaries in Firestore
- Introduce semantic cache for reusing similar replies
- Detect order stage and generate TL;DR summaries via Gemini

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log || tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68b0df6cacb8832aaef18beb443503f7