### PR TITLE
Stop processing threads after seller last message

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -1050,6 +1050,13 @@ class DuokeBot:
             if not pairs:
                 continue
 
+            last_role = pairs[-1][0]
+            if last_role == "seller":
+                print(
+                    "[DEBUG] conversa termina com mensagem do vendedor; encerrando ciclo"
+                )
+                break
+
             buyer_name = (order_info.get("buyer_name") or "").strip()
             summary = ""
             if buyer_name:


### PR DESCRIPTION
## Summary
- Halt the conversation processing loop when the latest message in a thread is from the seller, preventing responses to already-handled chats

## Testing
- `python -m py_compile src/duoke.py`
- `python -m src.run_once` *(fails: Sessão não encontrada. Execute `python -m src.login` para fazer login antes de iniciar o bot.)*


------
https://chatgpt.com/codex/tasks/task_e_68b0e5f2a59c832a849945aaab29d496