### PR TITLE
Use fallback reply when Gemini is unavailable

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -70,18 +70,19 @@ def decide_reply(
 
     resp = generate_reply(history, order_info=order_info, policy_context=policy_block)
     if not resp:
+        return True, RESP_FALLBACK_CURTO
+    if resp.action == "skip":
         return False, ""
     if resp.action != "reply":
-        return False, ""
+        return True, RESP_FALLBACK_CURTO
     if resp.confidence < settings.reply_confidence_threshold:
-        return False, ""
+        return True, RESP_FALLBACK_CURTO
     if not (
-        resp.policy_flags.nao_altera_endereco
-        and resp.policy_flags.nao_cobra_fora_app
+        resp.policy_flags.nao_altera_endereco and resp.policy_flags.nao_cobra_fora_app
     ):
-        return False, ""
+        return True, RESP_FALLBACK_CURTO
     if not validate_reply_text(resp.reply):
-        return False, ""
+        return True, RESP_FALLBACK_CURTO
 
     # Atualiza slots inferidos pelo modelo
     if order_info is not None:


### PR DESCRIPTION
## Summary
- ensure classifier replies with fallback text when Gemini cannot generate a reply
- skip conversations only when model explicitly requests to skip

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0e923365c832a8f0ea813af383870