### PR TITLE
Handle image-only chat messages for Gemini

### DIFF
--- a/src/duoke.py
+++ b/src/duoke.py
@@ -625,13 +625,21 @@ class DuokeBot:
 
             texts = await items.evaluate_all(
                 """
-                (els) => els.map(li => {
-                    const cls = (li.className || '').toLowerCase();
-                    const role = cls.includes('lt') ? 'buyer' : (cls.includes('rt') ? 'seller' : 'system');
-                    const txtNode = li.querySelector('div.text_cont, .bubble .text, .record_item .content');
-                    const txt = (txtNode?.innerText || '').trim();
-                    return txt && role !== 'system' ? [role, txt] : null;
-                }).filter(Boolean)
+                (els) => els
+                    .map(li => {
+                        const cls = (li.className || '').toLowerCase();
+                        const role = cls.includes('lt')
+                            ? 'buyer'
+                            : (cls.includes('rt') ? 'seller' : 'system');
+                        const txtNode = li.querySelector('div.text_cont, .bubble .text, .record_item .content');
+                        const txt = (txtNode?.innerText || '').trim();
+                        const hasImg = !!li.querySelector('img');
+                        if (role === 'system') return null;
+                        if (txt) return [role, txt];
+                        if (hasImg) return [role, '[imagem]'];
+                        return null;
+                    })
+                    .filter(Boolean)
             """
             )
             out = texts[-depth:]
@@ -654,11 +662,21 @@ class DuokeBot:
             except Exception:
                 break
 
-        buyer_sel = SEL.get("buyer_message", "ul.message_main li.lt .text_cont")
         try:
-            nodes = page.locator(buyer_sel)
+            nodes = page.locator("ul.message_main li.lt")
             msgs = await nodes.evaluate_all(
-                "(els) => els.map(el => (el.innerText || '').trim()).filter(Boolean)"
+                """
+                (els) => els
+                    .map(li => {
+                        const txtNode = li.querySelector('div.text_cont, .bubble .text, .record_item .content');
+                        const txt = (txtNode?.innerText || '').trim();
+                        const hasImg = !!li.querySelector('img');
+                        if (txt) return txt;
+                        if (hasImg) return '[imagem]';
+                        return null;
+                    })
+                    .filter(Boolean)
+            """
             )
             print(f"[DEBUG] Mensagens do cliente encontradas: {len(msgs)}")
             return msgs[-depth:]


### PR DESCRIPTION
## Summary
- Detect image attachments in chat messages
- Tag photo-only messages with placeholder `[imagem]` so Gemini receives context

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b192a4df7c832a8a6673129cb2b810