### PR TITLE
Export history from Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Por padrão, roda uma varredura a cada 120 segundos (config em `.env`).
 ## Exportar histórico de conversas
 
 A interface web possui um botão **Exportar histórico** na aba *Atendimentos* que permite
-baixar o arquivo `history.json` com todas as mensagens salvas pelo bot.
+baixar o arquivo `history.json` com todas as mensagens salvas pelo bot na
+coleção `history` do Firebase.
 
 ## Estrutura
 

--- a/app_ui.py
+++ b/app_ui.py
@@ -32,6 +32,7 @@ from src.config import settings
 from src.classifier import decide_reply
 from src.rules import load_rules, save_rules
 from src.cases import export_to_excel
+from src.history import fetch_all_histories
 from playwright.async_api import TimeoutError as PWTimeoutError
 
 # ===== Estado global simples =====
@@ -545,9 +546,13 @@ async def export_cases_xlsx():
 
 @app.get("/export-history")
 async def export_history():
-    p = Path("data/history.json")
-    if not p.exists():
+    data = fetch_all_histories()
+    if not data:
         return JSONResponse({"ok": False, "error": "Nenhum histórico ainda."}, status_code=404)
+    p = Path("data/history.json")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
     return FileResponse(str(p), media_type="application/json", filename="history.json")
 
 

--- a/src/history.py
+++ b/src/history.py
@@ -10,7 +10,7 @@ message.
 from __future__ import annotations
 
 import json
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 from urllib.request import Request, urlopen
 
 from .firebase_client import FIREBASE_CONFIG
@@ -102,4 +102,46 @@ def append_history(
             resp.read()
     except Exception:
         pass
+
+
+def fetch_all_histories() -> Dict[str, List[Tuple[str, str]]]:
+    """Return all conversation histories stored in Firestore.
+
+    The result is a mapping of ``buyer_name`` to a list of ``(role, text)``
+    tuples.  If no documents are found or an error occurs, an empty dict is
+    returned.
+    """
+
+    base_url = (
+        f"{BASE_URL}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents"
+    )
+    url = f"{base_url}/history?key={FIREBASE_CONFIG['apiKey']}"
+    out: Dict[str, List[Tuple[str, str]]] = {}
+    page_token = ""
+    try:
+        while True:
+            page_url = url + (f"&pageToken={page_token}" if page_token else "")
+            with urlopen(page_url) as resp:
+                data = json.load(resp)
+            for doc in data.get("documents", []):
+                name = doc.get("name", "").split("/")[-1]
+                values = (
+                    doc.get("fields", {})
+                    .get("messages", {})
+                    .get("arrayValue", {})
+                    .get("values", [])
+                )
+                items: List[Tuple[str, str]] = []
+                for v in values:
+                    f = v.get("mapValue", {}).get("fields", {})
+                    role = f.get("role", {}).get("stringValue", "")
+                    text = f.get("text", {}).get("stringValue", "")
+                    items.append((role, text))
+                out[name] = items
+            page_token = data.get("nextPageToken")
+            if not page_token:
+                break
+    except Exception:
+        return {}
+    return out
 


### PR DESCRIPTION
## Summary
- fetch all conversation histories stored in Firestore
- export /export-history endpoint to generate history.json from Firebase
- update README documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1b56b37cc832abaff5be197c4a696