### PR TITLE
Add debug log for Gemini prompt

### DIFF
--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -133,6 +133,7 @@ INSTRUÇÕES ADICIONAIS (NÃO MOSTRAR AO CLIENTE):
 {history}
 """.strip()
 
+        print(f"[DEBUG] Enviando para Gemini:\n{prompt}")
         resp = model.generate_content(prompt)
         text = (getattr(resp, "text", "") or "").strip()
 


### PR DESCRIPTION
## Summary
- add debug log to display the prompt being sent to Gemini

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5cbc25598832a880b3a37ef38dd19