### PR TITLE
Add Firestore atendimentos export button

### DIFF
--- a/app_ui.py
+++ b/app_ui.py
@@ -31,8 +31,10 @@ from src.duoke import DuokeBot
 from src.config import settings
 from src.classifier import decide_reply
 from src.rules import load_rules, save_rules
-from src.cases import export_to_excel
+from src.cases import export_to_excel, HEADER
 from src.history import fetch_all_histories
+from src.firebase_client import fetch_all_cases
+from openpyxl import Workbook
 from playwright.async_api import TimeoutError as PWTimeoutError
 
 # ===== Estado global simples =====
@@ -219,6 +221,7 @@ HTML = Template(
         <div class="row" style="margin-bottom:8px;">
           <a class="secondary" href="/export-cases-xlsx" style="text-decoration:none;padding:10px 14px;border:1px solid var(--br);">Exportar Excel</a>
           <a class="secondary" href="/export-history" style="text-decoration:none;padding:10px 14px;border:1px solid var(--br);">Exportar histórico</a>
+          <a class="secondary" href="/export-atendimentos" style="text-decoration:none;padding:10px 14px;border:1px solid var(--br);">Baixar atendimentos</a>
         </div>
         <table>
           <thead>
@@ -541,6 +544,28 @@ async def export_cases_xlsx():
         str(p),
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         filename="atendimentos.xlsx",
+    )
+
+
+@app.get("/export-atendimentos")
+async def export_atendimentos():
+    rows = fetch_all_cases()
+    if not rows:
+        return JSONResponse({"ok": False, "error": "Nenhum atendimento ainda."}, status_code=404)
+
+    p = Path("data/atendimentos_firestore.xlsx")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    wb = Workbook()
+    ws = wb.active
+    ws.append(HEADER)
+    for r in rows:
+        ws.append([r.get(h, "") for h in HEADER])
+    wb.save(p)
+
+    return FileResponse(
+        str(p),
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        filename="atendimentos_firestore.xlsx",
     )
 
 

--- a/src/firebase_client.py
+++ b/src/firebase_client.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict
+from typing import Dict, List
 from urllib.request import urlopen, Request
 
 FIREBASE_CONFIG = {
@@ -51,4 +51,36 @@ def save_case_document(case: Dict[str, str]) -> None:
             resp.read()
     except Exception:
         pass
+
+
+def fetch_all_cases() -> List[Dict[str, str]]:
+    """Fetch all documents from the Firestore 'atendimentos' collection."""
+    base = "https://firestore.googleapis.com/v1"
+    url = (
+        f"{base}/projects/{FIREBASE_CONFIG['projectId']}/databases/(default)/documents/"
+        f"atendimentos?key={FIREBASE_CONFIG['apiKey']}"
+    )
+
+    results: List[Dict[str, str]] = []
+    page_token = None
+
+    while True:
+        page_url = url + (f"&pageToken={page_token}" if page_token else "")
+        try:
+            with urlopen(page_url) as resp:
+                data = json.load(resp)
+        except Exception:
+            break
+
+        for doc in data.get("documents", []):
+            fields: Dict[str, str] = {}
+            for k, v in doc.get("fields", {}).items():
+                fields[k] = next(iter(v.values()), "")
+            results.append(fields)
+
+        page_token = data.get("nextPageToken")
+        if not page_token:
+            break
+
+    return results
 


### PR DESCRIPTION
## Summary
- add button in Atendimentos tab to download records from Firestore
- implement endpoint to export Firestore atendimentos to Excel
- add Firestore client helper to fetch all atendimentos documents

## Testing
- `python -m py_compile app_ui.py src/firebase_client.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b88f1accbc832aaecb2ec7aaeea82c