### PR TITLE
Add labels to saved conversations

### DIFF
--- a/src/cases.py
+++ b/src/cases.py
@@ -22,6 +22,7 @@ HEADER = [
     "variacao",
     "sku",
     "problema",
+    "etiqueta",
     "ultimas_7_msgs_comprador",
 ]
 
@@ -76,8 +77,19 @@ def infer_problema(buyer_msgs: List[str]) -> str:
     return ""
 
 
+def determine_label(problema: str) -> str:
+    """Converte a descrição do problema em uma etiqueta geral."""
+    p = (problema or "").lower()
+    if "reembolso" in p:
+        return "reembolso"
+    if "peça" in p or "peca" in p:
+        return "Peças faltando"
+    return "geral"
+
+
 def append_row(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
     problema = infer_problema(buyer_only)
+    etiqueta = determine_label(problema)
 
     _ensure_header()
     ultimas_msgs = " | ".join(
@@ -93,6 +105,7 @@ def append_row(order_info: Dict[str, Any], buyer_only: List[str]) -> None:
         order_info.get("variation", ""),
         order_info.get("sku", ""),
         problema,
+        etiqueta,
         ultimas_msgs,
     ]
 

--- a/src/duoke.py
+++ b/src/duoke.py
@@ -19,6 +19,7 @@ from .cases import (
     append_row as log_case,
     append_label as log_label,
     infer_problema,
+    determine_label,
 )
 from .history import get_history, append_history
 
@@ -1065,6 +1066,11 @@ class DuokeBot:
                 continue
 
             buyer_name = (order_info.get("buyer_name") or "").strip()
+            buyer_only = [t for r, t in pairs if r == "buyer"][-depth:]
+            problema = infer_problema(buyer_only)
+            etiqueta = determine_label(problema)
+            order_info["etiqueta"] = etiqueta
+            order_info["problema"] = problema
             if buyer_name:
                 stored = get_history(buyer_name)
                 if stored:
@@ -1077,8 +1083,6 @@ class DuokeBot:
                     buyer_name, pairs, order_info=order_info, max_depth=depth * 2
                 )
 
-            buyer_only = [t for r, t in pairs if r == "buyer"][-depth:]
-            problema = infer_problema(buyer_only)
             wants_parts = bool(buyer_only) and buyer_wants_missing_parts(buyer_only[-1])
 
             # Se a última mensagem do vendedor foi o texto de "quebra_com_foto"


### PR DESCRIPTION
## Summary
- Tag conversations with general labels like `reembolso` or `Peças faltando`
- Persist label in history exports and case logs

## Testing
- `python -m py_compile src/cases.py src/duoke.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9ceff4c68832ab3409653a7157b74